### PR TITLE
feat: integrate Oriel VeraSol LSS-7120 lamp and serial Keithley 2400 support

### DIFF
--- a/config/examples/verasol_glovebox.toml
+++ b/config/examples/verasol_glovebox.toml
@@ -1,0 +1,70 @@
+# VeraSol Glovebox — EPFL LPI glovebox IV station
+# Hardware: Oriel VeraSol LSS-7120 LED solar simulator (USB/USBTMC)
+#           Keithley 2400 SMU (RS-232, COM4)
+#
+# To use: copy to config/system_settings.toml and adjust paths and calibration values.
+#
+# Dependencies:
+#   pip install pyvisa pyvisa-py pymeasure
+# No NI-VISA driver installation required.
+
+[computer]
+hardware = "VerasolGlovebox"          # free label, used in log files
+os = "Windows 11"
+basePath = "C:\\Data"                  # root directory for measurement data
+sdPath = ""                            # scrambled backup copy directory; set "" to disable
+
+[IVsys]
+sysName = "IVLab"
+# fullSunReferenceCurrent is updated automatically each time you run a calibration.
+fullSunReferenceCurrent = 0.006129    # amps — reference diode current at 1 sun
+calibrationDateTime = ""
+referenceDiodeImax = 0.01             # amps — current compliance for reference diode channel
+saveDataAutomatic = false             # true = auto-save after each scan; false = prompt
+checkVOCBeforeScan = true             # measure Voc before each scan to verify illumination
+firstPointDwellTime = 5.0             # seconds — settling time at first voltage point
+MPPVoltageStepInitial = 0.002         # volts — initial MPP tracker step
+MPPVoltageStepMax = 0.002             # volts — maximum MPP tracker step
+MPPVoltageStepMin = 0.001             # volts — minimum MPP tracker step
+
+[lamp]
+brand = "VeraSol"
+model = "LSS-7120"                    # 19-channel LED solar simulator, USB/USBTMC
+"display name" = "Oriel VeraSol LSS-7120"
+emulate = false
+# visa_address: leave unset (or "") for automatic USB detection.
+# Set explicitly only if you have multiple USB instruments connected:
+# visa_address = ""
+visa_address = "USB0::0x1FDE::0x000A::71201042::INSTR"
+
+# Light levels offered in the GUI drop-down.
+# Keys = % sun shown to the user; values are unused by the VeraSol driver
+# (it converts the selected % directly to an amplitude in suns).
+[lamp.lightLevelDict]
+"100.0" = 1.0   # 1.0 sun  — AM1.5G standard
+"50.0"  = 0.5
+"20.0"  = 0.2
+"10.0"  = 0.1
+"0.0"   = 0     # Dark — turns output off
+
+[SMU]
+brand = "Keithley"
+model = "2400"                        # 2400 | 2401 | 2450 — pymeasure driver
+visa_address = "ASRL4::INSTR"         # serial port COM4 (pyvisa ASRL format)
+visa_library = "@py"                  # pyvisa-py backend (no NI-VISA required)
+# If you have NI-VISA installed, use the path to visa32.dll instead:
+#   visa_library = "C:\\Windows\\SysWOW64\\visa32.dll"
+emulate = false
+referenceDiodeSenseMode = "2wire"     # "2wire" or "4 wire"
+autorange = true
+useReferenceDiode = false             # glovebox typically has no reference diode
+
+# --- RS-232 serial parameters (only used for ASRL addresses) ---
+# These MUST match the Keithley's front-panel RS-232 settings, or every read
+# hangs until the timeout (VI_ERROR_TMO). Defaults: 9600 baud, CR terminators.
+# If you still get timeouts, check the instrument's COMM / RS-232 menu and set
+# the values below to match (common terminators: "\r", "\n", or "\r\n").
+baud_rate = 9600                      # instrument COMM menu: BAUD
+read_termination = "\n"               # instrument COMM menu: TERMINATOR <LF>
+write_termination = "\n"              # instrument COMM menu: TERMINATOR <LF>
+timeout_ms = 5000                     # VISA read timeout in milliseconds

--- a/docs/verasol/CLAUDE.md
+++ b/docs/verasol/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+**verasol** is a Python control library and desktop GUI for the **Oriel VeraSol LSS-7120 LED Solar Simulator** — a laboratory instrument for photovoltaic research. It controls 19 individually addressable LED channels (400–1100 nm) via USB using the USBTMC protocol.
+
+## Tech Stack
+
+- Python 3.9+, PySide6 (Qt 6), PyVISA / PyVISA-py
+- No build step; no formal test suite (hardware required for testing)
+
+## Running
+
+```bash
+# Install dependencies
+pip install pyvisa pyvisa-py PySide6
+
+# Launch GUI
+python verasol_gui.py
+
+# Use as library
+python -c "from verasol import VeraSol; print(VeraSol().identify())"
+```
+
+The GUI falls back to a stub mode (UI-only, no hardware) if the instrument is unavailable.
+
+## Architecture
+
+Two files:
+
+**`verasol.py`** — Low-level USBTMC driver. Key classes:
+- `VeraSol` — Main instrument class; use as a context manager (`with VeraSol() as lamp`)
+- `LampStatus` — Dataclass with decoded status flags (output_on, head_warming_up, head_overtemperature, etc.)
+- `LEDInfo` — Per-LED metadata (index, wavelength_nm, power_kw_m2, max_power_kw_m2)
+- `CalibrationMode`, `SpectrumMode` — Enums for mode selection
+- `list_instruments()` — Module-level function to discover USB VISA resources
+
+**`verasol_gui.py`** — PySide6 desktop control panel (~1357 lines). Key design:
+- `InstrumentWorker` runs in a separate `QThread`; all blocking hardware calls go through it
+- Worker communicates with GUI exclusively via Qt signals/slots (no direct cross-thread calls)
+- Tabs: Output, Spectrum (LED bar chart), Spectrum Memory, Calibration, Diagnostics, Log
+
+## Key Domain Details
+
+- **Amplitude**: 0.1–1.0 suns (1 sun = 1 kW/m²); enforced in `set_amplitude()`
+- **LED indices**: 1–24 (only 19 active); validated in `_validate_led_index()`
+- **Spectrum memory slots**: 0–10; slot 0 = factory AM1.5G (read-only)
+- **Protocol**: Every write command echoes `"Ready"` which `_write()` consumes; queries return stripped strings
+- **Warmup**: ~15 min to operating temperature; `wait_for_warmup()` blocks with polling
+- **LED self-test**: ~60-second cycle; call `run_led_test()` then `get_led_test_result(led)` per channel
+- **User calibration**: `perform_user_calibration()` rescales internal reference to 1.00 sun at the current setpoint

--- a/docs/verasol/README.md
+++ b/docs/verasol/README.md
@@ -1,0 +1,189 @@
+# verasol
+
+Python control software for the **Newport/Oriel VeraSol LSS-7120 LED Solar Simulator** — a 19-channel LED source covering 400–1100 nm, calibrated to the AM1.5G solar spectrum.
+
+---
+
+## Hardware connection
+
+1. Power on the VeraSol controller (front-panel switch).
+2. Connect the controller to the PC with a standard USB-B cable (same connector used by many lab instruments and printers).
+3. Wait for Windows to finish installing the device driver. The instrument uses the built-in Windows **IVI USBTMC** class driver — no third-party driver installation is needed.
+
+> **NI-VISA note:** If you have NI-VISA installed, the software will try it first. If NI-VISA does not enumerate the instrument (common when the device is bound to the Windows IVI driver instead of the NI driver), the software falls back automatically to direct USB access. No manual configuration is required either way.
+
+---
+
+## Installation
+
+Requires Python 3.9 or newer.
+
+```bash
+pip install PySide6 pyvisa pyvisa-py
+```
+
+Place both `verasol.py` and `verasol_gui.py` in the same folder.
+
+---
+
+## Running the GUI
+
+```bash
+py verasol_gui.py
+```
+
+The GUI opens immediately. If no instrument is connected it runs in **stub mode** (UI is fully functional but no hardware commands are sent) — useful for exploring the interface without the lamp.
+
+### Connecting to the instrument
+
+The **Connection** bar runs across the top of the window.
+
+| Control | Purpose |
+|---|---|
+| **Scan** | Detect available USB instruments and populate the resource drop-down |
+| Resource drop-down | Shows the detected device path; leave blank for auto-detect |
+| **Connect** | Open the connection (auto-detects the instrument if the field is empty) |
+| **Disconnect** | Close the connection cleanly |
+| ID field | Displays the instrument identification string once connected |
+
+On a typical Windows system, clicking **Connect** with an empty resource field is all that is needed — the software scans for the VeraSol automatically.
+
+### Status indicators
+
+Below the connection bar, four coloured dots show the current instrument state:
+
+| Indicator | Green | Red/Amber |
+|---|---|---|
+| **Output ON** | Output is active | Output is off |
+| **Head OK** | LED head connected | Head disconnected |
+| **Warm** | Operating temperature reached | Still warming up (amber) |
+| **Temp OK** | Temperature normal | Over-temperature fault |
+
+---
+
+## GUI tabs
+
+### Output
+
+Controls global output and intensity.
+
+- **OUTPUT ON / OFF button** — toggles the LED output. The button turns green when the output is active.
+- **Intensity slider** — sets the irradiance from 0.1 to 1.0 sun (1 sun = 1 kW/m²). Drag the slider or use the fine spinbox below it.
+- **Fine spinbox** — type or click the arrows for 0.010-sun steps; press **Apply** to send the value to the instrument.
+
+### LED Spectrum
+
+Shows and adjusts the power of all 19 individual LED channels (400–1100 nm).
+
+Each channel is displayed as a vertical bar coloured by its wavelength. The bar fills from bottom to top as power increases.
+
+**Adjusting a channel:**
+
+- **Click anywhere on the bar** — sets the channel power proportionally to the click height (top = maximum, bottom = zero). Click and drag to sweep smoothly.
+- **Spinbox (below each bar)** — shows the current power in kW/m². Use the arrow buttons or type a value directly; the bar updates in real time.
+
+Changes are sent to the instrument immediately as you interact with each channel.
+
+The x-axis runs from 400 nm (left) to 1100 nm (right / NIR).
+
+### Spectrum Memory
+
+Stores and recalls complete LED spectra.
+
+The instrument has 11 memory slots:
+
+| Slot | Contents |
+|---|---|
+| 0 | Factory AM1.5G spectrum (read-only) |
+| 1 | "Custom" spectrum, also accessible from the front panel |
+| 2–10 | User storage slots |
+
+- **Recall** — loads a stored spectrum into the active output.
+- **Store** — saves the current LED settings to a slot (slots 1–10 only).
+- **Quick Access** buttons recall the factory AM1.5G or the front-panel custom spectrum in one click.
+
+The active spectrum location is shown at the top of the tab.
+
+### Calibration
+
+Controls intensity calibration.
+
+**Calibration mode:**
+
+- **Factory Default** — uses the original factory intensity reference.
+- **User Offset** — applies a user-defined intensity offset on top of the factory calibration.
+
+**Performing a user calibration:**
+
+1. Place your reference irradiance meter under the head.
+2. Set the output to the desired level and let the lamp reach operating temperature.
+3. Adjust the amplitude until your meter reads exactly 1.00 sun.
+4. Press **Execute User Calibration**. The controller rescales its internal reference to 1.00 sun at the current set point and stores the offset.
+
+### Diagnostics
+
+Tools for checking instrument health.
+
+- **Fetch Errors** — queries the instrument error queue and displays any reported errors. An empty result means no errors.
+- **Run LED Self-Test** — triggers the built-in LED power self-test. The instrument cycles through all channels, measuring each LED's actual output power. This takes approximately 60 seconds. Results are shown in a table (measured vs expected power per channel). Do not change settings during the test.
+
+### Log
+
+A scrolling event log showing all commands sent to the instrument, responses received, errors, and connection events. Useful for debugging.
+
+---
+
+## Warmup
+
+The VeraSol requires approximately **15 minutes** to reach operating temperature after power-on. The **Warm** indicator turns green once the head is at temperature. Irradiance calibration is only accurate after warmup is complete.
+
+---
+
+## Library usage (Python API)
+
+`verasol.py` can be used directly as a Python library without the GUI:
+
+```python
+from verasol import VeraSol
+
+with VeraSol() as lamp:
+    print(lamp.identify())          # instrument ID string
+    lamp.set_amplitude(1.0)         # 1.0 sun
+    lamp.set_output(True)           # output ON
+    print(lamp.get_status())        # LampStatus(OUTPUT=ON, ...)
+    lamp.set_output(False)          # output OFF
+```
+
+**Key methods:**
+
+| Method | Description |
+|---|---|
+| `set_output(on)` | Turn output on/off |
+| `get_output()` | Return current output state |
+| `set_amplitude(suns)` | Set intensity (≥ 0.1 sun) |
+| `get_amplitude()` | Return current amplitude in suns |
+| `set_led_power(led, kw_m2)` | Set power of one LED channel (index 1–24) |
+| `get_led_info(led)` | Return wavelength, power, and max power for one channel |
+| `get_all_led_info()` | Return info for all 19 channels |
+| `recall_spectrum(location)` | Load a stored spectrum (0–10) |
+| `store_spectrum(location)` | Save current spectrum (1–10) |
+| `get_status()` | Return decoded `LampStatus` |
+| `get_errors()` | Drain and return the instrument error queue |
+| `perform_user_calibration()` | Execute user intensity calibration |
+| `list_instruments()` | Discover available USB VISA resources |
+
+```python
+# Discover what instruments are visible
+from verasol import list_instruments
+print(list_instruments())
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `verasol.py` | Low-level instrument driver (use standalone or with the GUI) |
+| `verasol_gui.py` | PySide6 desktop control panel |
+| `test_connection.py` | Minimal raw USB connection test (no GUI, no VISA) |

--- a/docs/verasol/test_connection.py
+++ b/docs/verasol/test_connection.py
@@ -1,0 +1,162 @@
+"""
+Quick connection and output test for the VeraSol LSS-7120.
+
+Works on Windows using the native IVI USBTMC class driver, bypassing
+the NI-VISA enumeration issue where NI-VISA doesn't expose the device
+as a USB INSTR resource.
+"""
+
+import ctypes
+import struct
+import time
+from ctypes import windll, create_string_buffer, c_ulong, byref
+
+DEVICE_PATH = (
+    r"\\?\USB#VID_1FDE&PID_000A&MI_00"
+    r"#6&109d9d3c&0&0000"
+    r"#{a9fdbb24-128a-11d5-9961-00108335e361}"
+)
+
+GENERIC_READ  = 0x80000000
+GENERIC_WRITE = 0x40000000
+OPEN_EXISTING = 3
+FILE_SHARE_READ  = 1
+FILE_SHARE_WRITE = 2
+
+
+class RawUSBTMC:
+    """Minimal USBTMC transport over the Windows IVI class driver."""
+
+    def __init__(self, path: str):
+        self._h = windll.kernel32.CreateFileW(
+            path,
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None, OPEN_EXISTING, 0, None,
+        )
+        if self._h == ctypes.c_void_p(-1).value:
+            raise OSError(f"Could not open device ({ctypes.GetLastError()}): {path}")
+        self._btag = 0
+
+    def close(self):
+        if self._h and self._h != -1:
+            windll.kernel32.CloseHandle(self._h)
+            self._h = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    def _next_tag(self) -> int:
+        self._btag = (self._btag % 255) + 1
+        return self._btag
+
+    def write(self, msg: str) -> None:
+        data = (msg.rstrip("\n") + "\n").encode()
+        tag = self._next_tag()
+        header = struct.pack(
+            "<BBBBIBxxx",
+            0x01, tag, (~tag) & 0xFF, 0,
+            len(data), 0x01,  # EOM bit set
+        )
+        packet = header + data
+        packet += b"\x00" * ((4 - len(packet) % 4) % 4)
+        buf = create_string_buffer(packet)
+        written = c_ulong(0)
+        if not windll.kernel32.WriteFile(self._h, buf, len(packet), byref(written), None):
+            raise OSError(f"WriteFile failed: {ctypes.GetLastError()}")
+
+    def read(self, max_bytes: int = 4096) -> str:
+        tag = self._next_tag()
+        req = struct.pack(
+            "<BBBBIBxxx",
+            0x02, tag, (~tag) & 0xFF, 0,
+            max_bytes, 0x00,
+        )
+        buf_req = create_string_buffer(req)
+        written = c_ulong(0)
+        windll.kernel32.WriteFile(self._h, buf_req, len(req), byref(written), None)
+
+        buf_resp = create_string_buffer(max_bytes + 12)
+        read_bytes = c_ulong(0)
+        if not windll.kernel32.ReadFile(self._h, buf_resp, max_bytes + 12, byref(read_bytes), None):
+            raise OSError(f"ReadFile failed: {ctypes.GetLastError()}")
+        n = read_bytes.value
+        if n < 12:
+            return ""
+        payload_len = struct.unpack_from("<I", buf_resp.raw, 4)[0]
+        return buf_resp.raw[12 : 12 + payload_len].decode("ascii", errors="replace").strip()
+
+    def query(self, msg: str) -> str:
+        self.write(msg)
+        return self.read()
+
+
+def run_test():
+    print("=" * 55)
+    print("VeraSol LSS-7120 Connection & Output Test")
+    print("=" * 55)
+
+    with RawUSBTMC(DEVICE_PATH) as dev:
+        # 1. Identity
+        idn = dev.query("*IDN?")
+        print(f"IDN : {idn}")
+
+        # 2. Status
+        status_raw = dev.query("STATUS?")
+        status_val = int(status_raw)
+        output_on       = bool(status_val & (1 << 0))
+        head_disconnect = bool(status_val & (1 << 2))
+        warming_up      = bool(status_val & (1 << 3))
+        overtemp        = bool(status_val & (1 << 4))
+        print(f"\nStatus (raw={status_val}):")
+        print(f"  Output on       : {output_on}")
+        print(f"  Head connected  : {not head_disconnect}")
+        print(f"  Warming up      : {warming_up}")
+        print(f"  Over-temperature: {overtemp}")
+
+        if head_disconnect:
+            print("\n[WARN] Head is disconnected — skipping output test.")
+            return
+
+        # 3. Current amplitude
+        amp = dev.query("AMPLITUDE?")
+        print(f"\nAmplitude: {amp} sun(s)")
+
+        # 4. Toggle output
+        initial_state = dev.query("OUTPUT?").strip()
+        print(f"\nCurrent output state : {initial_state}")
+
+        print("\n--- Turning OUTPUT ON ---")
+        dev.write("OUTPUT ON")
+        dev.read()                  # consume 'Ready'
+        time.sleep(0.5)
+        state = dev.query("OUTPUT?")
+        print(f"Output after ON cmd  : {state}")
+        assert state.strip() == "1", f"Expected '1', got {state!r}"
+
+        print("\n--- Turning OUTPUT OFF ---")
+        dev.write("OUTPUT OFF")
+        dev.read()                  # consume 'Ready'
+        time.sleep(0.5)
+        state = dev.query("OUTPUT?")
+        print(f"Output after OFF cmd : {state}")
+        assert state.strip() == "0", f"Expected '0', got {state!r}"
+
+        # Restore original state
+        if initial_state == "1":
+            dev.write("OUTPUT ON")
+            dev.read()
+            print("\n(Restored output to ON)")
+
+        # 5. Error queue
+        errors = dev.query("SYSTEM:ERROR?")
+        print(f"\nError queue: {errors}")
+
+        print("\n[PASS] All output tests passed.")
+
+
+if __name__ == "__main__":
+    run_test()

--- a/docs/verasol/verasol.py
+++ b/docs/verasol/verasol.py
@@ -1,0 +1,648 @@
+"""
+verasol.py — Python control library for the Oriel VeraSol LSS-7120 LED Solar Simulator.
+
+Communication is over USB via the USBTMC (USB Test and Measurement Class) protocol.
+Requires a VISA backend: install with `pip install pyvisa pyvisa-py` (or use NI-VISA).
+
+Usage example
+-------------
+    from verasol import VeraSol
+
+    with VeraSol() as lamp:
+        lamp.set_output(True)
+        lamp.set_amplitude(1.0)           # 1 sun
+        print(lamp.get_status())
+        lamp.set_output(False)
+
+References
+----------
+- Oriel Instruments VeraSol User's Guide (700482, May 2016)
+- Chapter 4 : Remote Operation (USB / USBTMC)
+- Chapter 5 : Command Reference
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+try:
+    import pyvisa
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "pyvisa is required: pip install pyvisa pyvisa-py"
+    ) from exc
+
+# Windows-only imports for the IVI USBTMC fallback transport
+if sys.platform == "win32":
+    import ctypes
+    import winreg
+    from ctypes import windll, create_string_buffer, c_ulong, byref as _byref
+    _WIN32_AVAILABLE = True
+else:
+    _WIN32_AVAILABLE = False
+
+# Device interface GUID assigned by the Windows IVI USBTMC class driver
+_WIN32_USBTMC_GUID = "{a9fdbb24-128a-11d5-9961-00108335e361}"
+# Substring present in the IDN string of every VeraSol instrument
+_VERASOL_IDN_HINT = "LSS-7120"
+
+
+# ---------------------------------------------------------------------------
+# Public data types
+# ---------------------------------------------------------------------------
+
+class SpectrumMode(str, Enum):
+    """Named spectrum slots understood by the controller."""
+    AM15G = "AM1.5G"   # Factory AM1.5G (memory location 0)
+    CUSTOM = "CUSTOM"  # Custom / user-defined (memory location 1, front-panel)
+
+
+class CalibrationMode(str, Enum):
+    DEFAULT = "DEFAULT"  # Factory calibration
+    USER = "USER"        # User intensity offset
+
+
+@dataclass
+class LampStatus:
+    """Decoded STATUS? response (bit-field, see manual p. 30)."""
+    output_on: bool
+    head_disconnected: bool
+    head_warming_up: bool
+    head_overtemperature: bool
+    raw: int
+
+    def __str__(self) -> str:
+        flags = []
+        if self.output_on:
+            flags.append("OUTPUT=ON")
+        if self.head_disconnected:
+            flags.append("HEAD_DISCONNECTED")
+        if self.head_warming_up:
+            flags.append("WARMING_UP")
+        if self.head_overtemperature:
+            flags.append("OVERTEMP")
+        return f"LampStatus({', '.join(flags) or 'OK'})"
+
+
+@dataclass
+class LEDInfo:
+    """Power and wavelength information for a single LED channel."""
+    index: int           # 1-based LED number (1-24)
+    wavelength_nm: float
+    power_kw_m2: float
+    max_power_kw_m2: float
+
+
+# ---------------------------------------------------------------------------
+# Windows IVI USBTMC fallback transport
+# ---------------------------------------------------------------------------
+
+class _WinUSBTMC:
+    """
+    Minimal USBTMC transport that talks to the Windows IVI USBTMC class driver
+    directly via Win32 file handles, bypassing NI-VISA's device enumeration.
+
+    Implements the write / read / query / close / timeout interface that
+    VeraSol expects from a pyvisa Resource object.
+    """
+
+    _GENERIC_RW    = 0x80000000 | 0x40000000   # GENERIC_READ | GENERIC_WRITE
+    _FILE_SHARE_RW = 0x01 | 0x02               # FILE_SHARE_READ | FILE_SHARE_WRITE
+    _OPEN_EXISTING = 3
+
+    def __init__(self, path: str, timeout_ms: int = 10_000) -> None:
+        if not _WIN32_AVAILABLE:
+            raise OSError("_WinUSBTMC is only supported on Windows.")
+        self.timeout           = timeout_ms   # stored; used by run_led_test()
+        self.read_termination  = "\n"
+        self.write_termination = "\n"
+        self._btag = 0
+        self._h = windll.kernel32.CreateFileW(
+            path, self._GENERIC_RW, self._FILE_SHARE_RW,
+            None, self._OPEN_EXISTING, 0, None,
+        )
+        if self._h == -1:
+            raise OSError(
+                f"Cannot open USBTMC device (err={ctypes.GetLastError()}): {path}"
+            )
+
+    def close(self) -> None:
+        if self._h not in (None, -1):
+            windll.kernel32.CloseHandle(self._h)
+            self._h = None
+
+    def _next_tag(self) -> int:
+        self._btag = (self._btag % 255) + 1
+        return self._btag
+
+    def write(self, msg: str) -> None:
+        data = (msg.rstrip("\n") + self.write_termination).encode()
+        tag  = self._next_tag()
+        header = struct.pack(
+            "<BBBBIBxxx",
+            0x01, tag, (~tag) & 0xFF, 0,   # DEV_DEP_MSG_OUT, bTag, ~bTag, reserved
+            len(data), 0x01,               # TransferSize, bmTransferAttributes (EOM)
+        )
+        packet = header + data
+        packet += b"\x00" * ((4 - len(packet) % 4) % 4)   # 4-byte alignment padding
+        buf     = create_string_buffer(packet)
+        written = c_ulong(0)
+        if not windll.kernel32.WriteFile(self._h, buf, len(packet), _byref(written), None):
+            raise OSError(f"USBTMC WriteFile failed: {ctypes.GetLastError()}")
+
+    def read(self) -> str:
+        tag = self._next_tag()
+        req = struct.pack(
+            "<BBBBIBxxx",
+            0x02, tag, (~tag) & 0xFF, 0,   # REQUEST_DEV_DEP_MSG_IN
+            4096, 0x00,                    # TransferSize, bmTransferAttributes
+        )
+        buf_req = create_string_buffer(req)
+        written = c_ulong(0)
+        windll.kernel32.WriteFile(self._h, buf_req, len(req), _byref(written), None)
+        buf_resp  = create_string_buffer(4096 + 12)
+        read_bytes = c_ulong(0)
+        if not windll.kernel32.ReadFile(
+            self._h, buf_resp, 4096 + 12, _byref(read_bytes), None
+        ):
+            raise OSError(f"USBTMC ReadFile failed: {ctypes.GetLastError()}")
+        n = read_bytes.value
+        if n < 12:
+            return ""
+        payload_len = struct.unpack_from("<I", buf_resp.raw, 4)[0]
+        # A 0-byte payload with EOM set is the device's command acknowledgement.
+        # NI-VISA translates this to the string "Ready"; we do the same so that
+        # verasol._write() can check for it without knowing which transport is used.
+        if payload_len == 0 and (buf_resp.raw[8] & 0x01):
+            return "Ready"
+        raw = buf_resp.raw[12 : 12 + payload_len].decode("ascii", errors="replace")
+        return raw.rstrip(self.read_termination or "\n")
+
+    def query(self, msg: str) -> str:
+        self.write(msg)
+        return self.read()
+
+
+def _find_win_usbtmc_device(idn_hint: str = _VERASOL_IDN_HINT) -> Optional[str]:
+    """
+    Search the Windows device-interface registry for a USBTMC instrument whose
+    ``*IDN?`` response contains *idn_hint*.  Returns the Win32 device path on
+    success, or *None* if no matching instrument is found.
+    """
+    if not _WIN32_AVAILABLE:
+        return None
+    key_path = (
+        r"SYSTEM\CurrentControlSet\Control\DeviceClasses"
+        rf"\{_WIN32_USBTMC_GUID}"
+    )
+    try:
+        root = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path)
+    except FileNotFoundError:
+        return None
+    i = 0
+    while True:
+        try:
+            dev_key_name = winreg.EnumKey(root, i)
+        except OSError:
+            break
+        i += 1
+        # Registry key names use ##?# prefix; Win32 paths use \\?\
+        device_path = "\\\\?\\" + dev_key_name[4:]
+        try:
+            instr = _WinUSBTMC(device_path)
+            idn   = instr.query("*IDN?")
+            instr.close()
+            if idn_hint in idn:
+                return device_path
+        except Exception:
+            pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main driver class
+# ---------------------------------------------------------------------------
+
+class VeraSol:
+    """
+    Driver for the Oriel VeraSol LSS-7120 LED Solar Simulator Controller.
+
+    Parameters
+    ----------
+    resource_name:
+        VISA resource string, e.g. ``"USB0::0x1028::0x0001::71201234::INSTR"``.
+        When *None* (default) the driver opens the first matching USB instrument.
+    timeout_ms:
+        VISA read/write timeout in milliseconds (default 10 000 ms).
+
+    Can be used as a context manager::
+
+        with VeraSol() as lamp:
+            lamp.set_amplitude(0.5)
+    """
+
+    # Default VISA identifier substring used for auto-discovery
+    _ID_QUERY_HINT = "LSS-7120"
+    # Number of individually addressable LED channels
+    NUM_LEDS = 19
+
+    def __init__(
+        self,
+        resource_name: Optional[str] = None,
+        timeout_ms: int = 10_000,
+    ) -> None:
+        self._rm = None
+
+        # Direct Windows IVI USBTMC path — bypass pyvisa entirely
+        if resource_name and resource_name.startswith("\\\\?\\"):
+            self._resource_name = resource_name
+            self._instr = _WinUSBTMC(resource_name, timeout_ms)
+            return
+
+        # Primary path: use pyvisa (NI-VISA or pyvisa-py)
+        try:
+            self._rm = pyvisa.ResourceManager()
+            self._resource_name = resource_name or self._find_resource()
+            self._instr = self._rm.open_resource(self._resource_name)
+            self._instr.timeout = timeout_ms
+            # USBTMC termination characters (manual p. 26)
+            self._instr.read_termination  = "\n"
+            self._instr.write_termination = "\n"
+            return
+        except (RuntimeError, pyvisa.errors.VisaIOError):
+            if self._rm is not None:
+                try:
+                    self._rm.close()
+                except Exception:
+                    pass
+                self._rm = None
+
+        # Fallback: Windows IVI USBTMC class driver (auto-discover)
+        win_path = _find_win_usbtmc_device()
+        if win_path is None:
+            raise RuntimeError(
+                "No VeraSol instrument found via VISA or the Windows IVI USBTMC "
+                "driver.  Check the USB cable and VISA driver installation."
+            )
+        self._resource_name = win_path
+        self._instr = _WinUSBTMC(win_path, timeout_ms)
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "VeraSol":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release the VISA resource."""
+        try:
+            self._instr.close()
+        finally:
+            if self._rm is not None:
+                self._rm.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _find_resource(self) -> str:
+        """Return the first USB resource that identifies as an LSS-7120."""
+        resources = self._rm.list_resources("USB?*INSTR")
+        if not resources:
+            raise RuntimeError(
+                "No USB INSTR resources found. Check the USB cable and VISA drivers."
+            )
+        for name in resources:
+            try:
+                instr = self._rm.open_resource(name)
+                idn = instr.query("*IDN?").strip()
+                instr.close()
+                if self._ID_QUERY_HINT in idn:
+                    return name
+            except Exception:
+                pass
+        # Fall back to the first resource and let the user sort it out
+        return resources[0]
+
+    def _write(self, cmd: str) -> None:
+        """Send a command and consume the mandatory 'Ready' acknowledgement."""
+        self._instr.write(cmd)
+        ack = self._instr.read().strip()
+        if ack.lower() != "ready":
+            raise RuntimeError(
+                f"Unexpected acknowledgement for command '{cmd!r}': {ack!r}"
+            )
+
+    def _query(self, cmd: str) -> str:
+        """Send a query and return the stripped response string."""
+        return self._instr.query(cmd).strip()
+
+    # ------------------------------------------------------------------
+    # Identification
+    # ------------------------------------------------------------------
+
+    def identify(self) -> str:
+        """
+        Return the instrument identification string.
+
+        Example: ``"Newport Corporation,LSS-7120,71201234,1.01"``
+        """
+        return self._query("*IDN?")
+
+    # ------------------------------------------------------------------
+    # Output control
+    # ------------------------------------------------------------------
+
+    def set_output(self, on: bool) -> None:
+        """Turn the LED output on (``True``) or off (``False``)."""
+        self._write(f"OUTPUT {'ON' if on else 'OFF'}")
+
+    def get_output(self) -> bool:
+        """Return *True* if the LED output is currently on."""
+        response = self._query("OUTPUT?")
+        return response.strip().upper() in ("ON", "1")
+
+    # ------------------------------------------------------------------
+    # Amplitude / intensity
+    # ------------------------------------------------------------------
+
+    def set_amplitude(self, suns: float) -> None:
+        """
+        Set the output intensity.
+
+        Parameters
+        ----------
+        suns:
+            Target irradiance in suns (0.1 – 1.0).  1.0 sun = 1 kW m⁻².
+        """
+        if suns < 0.1:
+            raise ValueError(f"Amplitude must be ≥ 0.1 suns, got {suns}.")
+        self._write(f"AMPLITUDE {suns:.3f}")
+
+    def get_amplitude(self) -> float:
+        """Return the current output amplitude in suns."""
+        return float(self._query("AMPLITUDE?"))
+
+    # ------------------------------------------------------------------
+    # Individual LED power
+    # ------------------------------------------------------------------
+
+    def set_led_power(self, led: int, power_kw_m2: float) -> None:
+        """
+        Set the output power of a single LED channel.
+
+        Parameters
+        ----------
+        led:
+            LED index, 1-based (1 – 24).
+        power_kw_m2:
+            Desired power in kW m⁻² (0.0 – channel maximum).
+        """
+        self._validate_led_index(led)
+        self._write(f"LEDPOWER {led},{power_kw_m2:.4f}")
+
+    def get_led_power(self, led: int) -> float:
+        """Return the current power set-point of *led* in kW m⁻²."""
+        self._validate_led_index(led)
+        return float(self._query(f"LEDPOWER? {led}"))
+
+    def get_led_max_power(self, led: int) -> float:
+        """Return the maximum allowed power of *led* in kW m⁻²."""
+        self._validate_led_index(led)
+        return float(self._query(f"LEDMAXPOWER? {led}"))
+
+    def get_led_wavelength(self, led: int) -> float:
+        """Return the peak wavelength of *led* in nm."""
+        self._validate_led_index(led)
+        return float(self._query(f"LEDWAVELENGTH? {led}"))
+
+    def get_led_info(self, led: int) -> LEDInfo:
+        """Return a :class:`LEDInfo` summary for *led*."""
+        return LEDInfo(
+            index=led,
+            wavelength_nm=self.get_led_wavelength(led),
+            power_kw_m2=self.get_led_power(led),
+            max_power_kw_m2=self.get_led_max_power(led),
+        )
+
+    def get_all_led_info(self) -> list[LEDInfo]:
+        """Return :class:`LEDInfo` for every LED channel (1 – NUM_LEDS)."""
+        return [self.get_led_info(i) for i in range(1, self.NUM_LEDS + 1)]
+
+    @staticmethod
+    def _validate_led_index(led: int) -> None:
+        if not (1 <= led <= 24):
+            raise ValueError(f"LED index must be 1-24, got {led}.")
+
+    # ------------------------------------------------------------------
+    # Spectrum management
+    # ------------------------------------------------------------------
+
+    def store_spectrum(self, location: int) -> None:
+        """
+        Store the current LED spectrum to a memory slot.
+
+        Parameters
+        ----------
+        location:
+            Memory location 1 – 10.  Location 0 is reserved for the factory
+            AM1.5G spectrum and cannot be overwritten.
+        """
+        if not (1 <= location <= 10):
+            raise ValueError(f"Storage location must be 1-10, got {location}.")
+        self._write(f"SPECTRUM:STORE {location}")
+
+    def recall_spectrum(self, location: int) -> None:
+        """
+        Recall a previously stored spectrum.
+
+        Parameters
+        ----------
+        location:
+            0  → factory AM1.5G spectrum.
+            1  → the "custom" spectrum selectable from the front panel.
+            2-10 → user storage slots.
+        """
+        if not (0 <= location <= 10):
+            raise ValueError(f"Storage location must be 0-10, got {location}.")
+        self._write(f"SPECTRUM:RECALL {location}")
+
+    def get_active_spectrum_location(self) -> int:
+        """Return the memory-location number of the currently active spectrum."""
+        return int(self._query("SPECTRUM:ACTIVE?"))
+
+    # ------------------------------------------------------------------
+    # Calibration
+    # ------------------------------------------------------------------
+
+    def set_calibration_mode(self, mode: CalibrationMode) -> None:
+        """
+        Select factory (*DEFAULT*) or user-offset (*USER*) intensity calibration.
+        """
+        value = 0 if mode == CalibrationMode.DEFAULT else 1
+        self._write(f"USERCAL:SELECT {value}")
+
+    def get_calibration_mode(self) -> CalibrationMode:
+        """Return the current calibration mode."""
+        raw = int(self._query("USERCAL:SELECT?"))
+        return CalibrationMode.USER if raw else CalibrationMode.DEFAULT
+
+    def perform_user_calibration(self) -> None:
+        """
+        Execute the user-intensity calibration: rescales the current output to
+        read 1.00 sun on the front-panel display and stores the offset.
+        """
+        self._write("USERCAL:PERFORM")
+
+    # ------------------------------------------------------------------
+    # Status and diagnostics
+    # ------------------------------------------------------------------
+
+    def get_status(self) -> LampStatus:
+        """
+        Return a decoded :class:`LampStatus` from the ``STATUS?`` query.
+
+        Bit definitions (manual p. 30):
+        - bit 0: output on
+        - bit 2: head disconnected
+        - bit 3: head warming up
+        - bit 4: head over-temperature
+        """
+        raw = int(self._query("STATUS?"))
+        return LampStatus(
+            output_on=bool(raw & (1 << 0)),
+            head_disconnected=bool(raw & (1 << 2)),
+            head_warming_up=bool(raw & (1 << 3)),
+            head_overtemperature=bool(raw & (1 << 4)),
+            raw=raw,
+        )
+
+    def get_errors(self) -> list[str]:
+        """
+        Drain and return all queued error strings from the instrument.
+
+        An empty list means no errors.  The manual (p. 42) defines error codes
+        -104, -113, -115, -123, -224, -420.
+        """
+        errors: list[str] = []
+        while True:
+            response = self._query("ERROR?")
+            if response.startswith("0"):
+                break
+            errors.append(response)
+        return errors
+
+    # ------------------------------------------------------------------
+    # LED self-test
+    # ------------------------------------------------------------------
+
+    def run_led_test(self, timeout_s: float = 60.0) -> bool:
+        """
+        Trigger the LED self-test sequence (``LEDTEST:POWER?``).
+
+        The controller cycles through each LED, measuring output power.
+        Returns *True* on success, *False* on hardware failure.
+
+        Parameters
+        ----------
+        timeout_s:
+            Maximum seconds to wait for the test to finish (default 60 s).
+            The manual notes the test takes "several seconds".
+        """
+        original_timeout = self._instr.timeout
+        self._instr.timeout = int(timeout_s * 1000)
+        try:
+            result = self._query("LEDTEST:POWER?")
+        finally:
+            self._instr.timeout = original_timeout
+        return result.strip() == "1"
+
+    def get_led_test_result(self, led: int) -> tuple[float, float]:
+        """
+        Return ``(user_power, factory_power)`` in kW m⁻² for *led* from the
+        last completed self-test (``LEDTEST:RESULT?``).
+        """
+        self._validate_led_index(led)
+        response = self._query(f"LEDTEST:RESULT? {led}")
+        parts = [p.strip() for p in response.split(",")]
+        return float(parts[0]), float(parts[1])
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+
+    def wait_for_warmup(self, poll_interval_s: float = 5.0, timeout_s: float = 900.0) -> None:
+        """
+        Block until the LED head reaches operating temperature.
+
+        The manual states the head typically takes about 15 minutes to reach
+        nominal operating temperature.
+
+        Parameters
+        ----------
+        poll_interval_s:
+            How often to poll the status (default 5 s).
+        timeout_s:
+            Maximum wait time in seconds (default 900 s = 15 min).
+
+        Raises
+        ------
+        TimeoutError
+            If the head has not warmed up within *timeout_s*.
+        """
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            status = self.get_status()
+            if status.head_disconnected:
+                raise RuntimeError("LED head is disconnected — check the CC720 cable.")
+            if not status.head_warming_up:
+                return
+            time.sleep(poll_interval_s)
+        raise TimeoutError(
+            f"LED head did not reach operating temperature within {timeout_s:.0f} s."
+        )
+
+    def set_spectrum_am15g(self) -> None:
+        """Convenience: recall the factory AM1.5G spectrum (location 0)."""
+        self.recall_spectrum(0)
+
+    def set_spectrum_custom(self) -> None:
+        """Convenience: recall the front-panel 'custom' spectrum (location 1)."""
+        self.recall_spectrum(1)
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience function
+# ---------------------------------------------------------------------------
+
+def list_instruments() -> list[str]:
+    """
+    Return resource strings for all connected USB INSTR / USBTMC devices.
+
+    On Windows, includes instruments visible through the IVI USBTMC class
+    driver even when NI-VISA does not enumerate them as USB INSTR resources.
+    """
+    rm = pyvisa.ResourceManager()
+    try:
+        resources: list[str] = list(rm.list_resources("USB?*INSTR"))
+    except Exception:
+        resources = []
+    finally:
+        rm.close()
+
+    # Windows fallback: find any VeraSol reachable via the IVI USBTMC driver
+    # that is not already listed as a VISA USB resource.
+    win_path = _find_win_usbtmc_device()
+    if win_path is not None and win_path not in resources:
+        resources.append(win_path)
+
+    return resources

--- a/docs/verasol/verasol_gui.py
+++ b/docs/verasol/verasol_gui.py
@@ -1,0 +1,1397 @@
+"""
+verasol_gui.py — PySide6 control panel for the Oriel VeraSol LSS-7120 LED Solar Simulator.
+
+Requires:
+    pip install PySide6 pyvisa pyvisa-py
+
+Place verasol.py in the same directory, then run:
+    python verasol_gui.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import Optional
+
+from PySide6.QtCore import (
+    Qt, QThread, Signal, QTimer, QObject, Slot,
+)
+from PySide6.QtGui import QColor, QFont, QPalette, QIcon, QPainter
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QGridLayout, QGroupBox, QLabel, QPushButton, QSlider, QDoubleSpinBox,
+    QComboBox, QSpinBox, QTextEdit, QTabWidget, QSplitter, QFrame,
+    QProgressBar, QTableWidget, QTableWidgetItem, QHeaderView,
+    QMessageBox, QStatusBar, QCheckBox, QSizePolicy,
+)
+
+# ---------------------------------------------------------------------------
+# Try to import the verasol driver; fall back to a stub for UI development
+# ---------------------------------------------------------------------------
+try:
+    from verasol import VeraSol, CalibrationMode, LampStatus, LEDInfo, list_instruments
+    DRIVER_AVAILABLE = True
+except Exception as _import_err:  # noqa: BLE001
+    DRIVER_AVAILABLE = False
+    _IMPORT_ERROR = str(_import_err)
+
+    # ---- Minimal stubs so the GUI can be laid out without hardware ----
+    from enum import Enum
+    from dataclasses import dataclass
+
+    class CalibrationMode(str, Enum):
+        DEFAULT = "DEFAULT"
+        USER = "USER"
+
+    @dataclass
+    class LampStatus:
+        output_on: bool = False
+        head_disconnected: bool = True
+        head_warming_up: bool = False
+        head_overtemperature: bool = False
+        raw: int = 4
+
+    @dataclass
+    class LEDInfo:
+        index: int = 1
+        wavelength_nm: float = 500.0
+        power_kw_m2: float = 0.05
+        max_power_kw_m2: float = 0.10
+
+    def list_instruments():
+        return []
+
+    class VeraSol:  # type: ignore[no-redef]
+        NUM_LEDS = 19
+        def __init__(self, resource_name=None, timeout_ms=10000): pass
+        def close(self): pass
+        def identify(self): return "STUB,LSS-7120,00000000,0.00"
+        def set_output(self, on): pass
+        def get_output(self): return False
+        def set_amplitude(self, suns): pass
+        def get_amplitude(self): return 1.0
+        def set_led_power(self, led, power): pass
+        def get_led_power(self, led): return 0.05
+        def get_led_max_power(self, led): return 0.10
+        def get_led_wavelength(self, led): return 400 + (led - 1) * 37
+        def get_led_info(self, led):
+            return LEDInfo(led, 400 + (led-1)*37, 0.05, 0.10)
+        def get_all_led_info(self):
+            return [self.get_led_info(i) for i in range(1, self.NUM_LEDS + 1)]
+        def store_spectrum(self, loc): pass
+        def recall_spectrum(self, loc): pass
+        def get_active_spectrum_location(self): return 0
+        def set_calibration_mode(self, mode): pass
+        def get_calibration_mode(self): return CalibrationMode.DEFAULT
+        def perform_user_calibration(self): pass
+        def get_status(self): return LampStatus()
+        def get_errors(self): return []
+        def run_led_test(self, timeout_s=60): return True
+        def get_led_test_result(self, led): return (0.05, 0.05)
+
+
+# ---------------------------------------------------------------------------
+# Colour helpers
+# ---------------------------------------------------------------------------
+
+def _wavelength_to_rgb(nm: float) -> tuple[int, int, int]:
+    """Rough perceptual colour for a given wavelength (400–1100 nm)."""
+    if nm < 450:
+        r, g, b = 120, 0, 220
+    elif nm < 500:
+        t = (nm - 450) / 50
+        r, g, b = int(120 * (1 - t)), 0, int(220 + 35 * t)
+    elif nm < 570:
+        t = (nm - 500) / 70
+        r, g, b = 0, int(200 * t), 255
+    elif nm < 590:
+        t = (nm - 570) / 20
+        r, g, b = int(255 * t), 200, int(255 * (1 - t))
+    elif nm < 625:
+        t = (nm - 590) / 35
+        r, g, b = 255, int(200 * (1 - t)), 0
+    elif nm < 750:
+        r, g, b = 200, 0, 0
+    else:
+        # Near-IR – shown as dark red / maroon
+        v = max(60, int(180 - (nm - 750) / 3.5))
+        r, g, b = v, 0, 0
+    return r, g, b
+
+
+# ---------------------------------------------------------------------------
+# Worker thread – keeps all instrument I/O off the GUI thread
+# ---------------------------------------------------------------------------
+
+class InstrumentWorker(QObject):
+    """Runs blocking VeraSol calls in a QThread."""
+
+    # Signals emitted back to the GUI
+    connected = Signal(str)          # IDN string
+    disconnected = Signal()
+    error = Signal(str)              # human-readable error message
+    status_updated = Signal(object)  # LampStatus
+    amplitude_updated = Signal(float)
+    output_updated = Signal(bool)
+    led_info_updated = Signal(list)  # list[LEDInfo]
+    spectrum_location_updated = Signal(int)
+    calibration_mode_updated = Signal(str)
+    errors_received = Signal(list)   # list[str]
+    led_test_finished = Signal(bool, list)  # (passed, list[tuple])
+    log_message = Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lamp: Optional[VeraSol] = None
+
+    # ---- connection ----
+
+    @Slot(str)
+    def connect(self, resource_name: str) -> None:
+        try:
+            self._lamp = VeraSol(resource_name or None)
+            idn = self._lamp.identify()
+            self.connected.emit(idn)
+            self.log_message.emit(f"Connected: {idn}")
+            self._refresh_all()
+        except Exception as exc:
+            self.error.emit(f"Connection failed: {exc}")
+            self._lamp = None
+
+    @Slot()
+    def disconnect(self) -> None:
+        if self._lamp:
+            try:
+                self._lamp.close()
+            except Exception:
+                pass
+            self._lamp = None
+        self.disconnected.emit()
+        self.log_message.emit("Disconnected.")
+
+    def _require_lamp(self) -> bool:
+        if self._lamp is None:
+            self.error.emit("Not connected to instrument.")
+            return False
+        return True
+
+    def _refresh_all(self) -> None:
+        self._refresh_status()
+        self._refresh_amplitude()
+        self._refresh_output()
+        self._refresh_leds()
+        self._refresh_spectrum()
+        self._refresh_cal_mode()
+
+    # ---- status poll ----
+
+    @Slot()
+    def poll_status(self) -> None:
+        if not self._lamp:
+            return
+        try:
+            self.status_updated.emit(self._lamp.get_status())
+        except Exception as exc:
+            self.log_message.emit(f"[poll] {exc}")
+
+    def _refresh_status(self) -> None:
+        try:
+            self.status_updated.emit(self._lamp.get_status())
+        except Exception:
+            pass
+
+    # ---- output ----
+
+    @Slot(bool)
+    def set_output(self, on: bool) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self._lamp.set_output(on)
+            self.output_updated.emit(on)
+            self.log_message.emit(f"Output {'ON' if on else 'OFF'}")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    def _refresh_output(self) -> None:
+        try:
+            self.output_updated.emit(self._lamp.get_output())
+        except Exception:
+            pass
+
+    # ---- amplitude ----
+
+    @Slot(float)
+    def set_amplitude(self, suns: float) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self._lamp.set_amplitude(suns)
+            self.amplitude_updated.emit(suns)
+            self.log_message.emit(f"Amplitude set to {suns:.3f} sun(s)")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    def _refresh_amplitude(self) -> None:
+        try:
+            self.amplitude_updated.emit(self._lamp.get_amplitude())
+        except Exception:
+            pass
+
+    # ---- LED power ----
+
+    @Slot(int, float)
+    def set_led_power(self, led: int, power: float) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self._lamp.set_led_power(led, power)
+            self.log_message.emit(f"LED {led} power → {power:.4f} kW/m²")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    @Slot()
+    def refresh_leds(self) -> None:
+        self._refresh_leds()
+
+    def _refresh_leds(self) -> None:
+        if not self._lamp:
+            return
+        try:
+            info = self._lamp.get_all_led_info()
+            self.led_info_updated.emit(info)
+        except Exception as exc:
+            self.log_message.emit(f"[LED refresh] {exc}")
+
+    # ---- spectrum ----
+
+    @Slot(int)
+    def recall_spectrum(self, location: int) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self._lamp.recall_spectrum(location)
+            self._refresh_leds()
+            self.spectrum_location_updated.emit(location)
+            self.log_message.emit(f"Recalled spectrum from slot {location}")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    @Slot(int)
+    def store_spectrum(self, location: int) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self._lamp.store_spectrum(location)
+            self.log_message.emit(f"Stored spectrum to slot {location}")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    def _refresh_spectrum(self) -> None:
+        try:
+            self.spectrum_location_updated.emit(self._lamp.get_active_spectrum_location())
+        except Exception:
+            pass
+
+    # ---- calibration ----
+
+    @Slot(str)
+    def set_calibration_mode(self, mode_str: str) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            mode = CalibrationMode(mode_str)
+            self._lamp.set_calibration_mode(mode)
+            self.calibration_mode_updated.emit(mode_str)
+            self.log_message.emit(f"Calibration mode → {mode_str}")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    @Slot()
+    def perform_user_cal(self) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self._lamp.perform_user_calibration()
+            self.log_message.emit("User calibration performed (output rescaled to 1.00 sun)")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    def _refresh_cal_mode(self) -> None:
+        try:
+            mode = self._lamp.get_calibration_mode()
+            self.calibration_mode_updated.emit(mode.value)
+        except Exception:
+            pass
+
+    # ---- errors ----
+
+    @Slot()
+    def fetch_errors(self) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            errs = self._lamp.get_errors()
+            self.errors_received.emit(errs)
+            if errs:
+                self.log_message.emit(f"Instrument errors: {'; '.join(errs)}")
+            else:
+                self.log_message.emit("No instrument errors queued.")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    # ---- LED self-test ----
+
+    @Slot()
+    def run_led_test(self) -> None:
+        if not self._require_lamp():
+            return
+        try:
+            self.log_message.emit("Running LED self-test (may take ~60 s)…")
+            passed = self._lamp.run_led_test(timeout_s=90)
+            results = []
+            for i in range(1, self._lamp.NUM_LEDS + 1):
+                try:
+                    user_p, factory_p = self._lamp.get_led_test_result(i)
+                    results.append((i, user_p, factory_p))
+                except Exception:
+                    results.append((i, None, None))
+            self.led_test_finished.emit(passed, results)
+            self.log_message.emit(f"LED test {'PASSED' if passed else 'FAILED'}")
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+
+# ---------------------------------------------------------------------------
+# LED bar widget (mimics front-panel bargraph)
+# ---------------------------------------------------------------------------
+
+class _SegmentBar(QWidget):
+    """Clickable vertical power bar drawn with QPainter."""
+
+    clicked = Signal(float)   # emits fraction 0.0–1.0
+
+    def __init__(self, color: QColor, segments: int = 10, parent=None) -> None:
+        super().__init__(parent)
+        self._color = color
+        self._n = segments
+        self._filled = 0
+        self._output_on = False
+        self.setFixedWidth(28)
+        self.setCursor(Qt.PointingHandCursor)
+
+    def set_state(self, filled: int, output_on: bool) -> None:
+        if filled != self._filled or output_on != self._output_on:
+            self._filled = filled
+            self._output_on = output_on
+            self.update()
+
+    def paintEvent(self, event) -> None:
+        painter = QPainter(self)
+        h, w, n = self.height(), self.width(), self._n
+        g = 1  # gap between segments
+        seg_h = (h - g * (n - 1)) / n
+        on_color = self._color if self._output_on else QColor(180, 100, 0)
+        off_color = QColor(40, 40, 40)
+        for i in range(n):
+            y = int(h - (i + 1) * seg_h - i * g)
+            sh = max(1, int(seg_h))
+            painter.fillRect(0, y, w, sh, on_color if i < self._filled else off_color)
+
+    def _fraction(self, y: float) -> float:
+        return max(0.0, min(1.0, 1.0 - y / max(1, self.height())))
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit(self._fraction(event.position().y()))
+
+    def mouseMoveEvent(self, event) -> None:
+        if event.buttons() & Qt.LeftButton:
+            self.clicked.emit(self._fraction(event.position().y()))
+
+
+class LEDBarWidget(QWidget):
+    """A vertical bar + label representing one LED channel."""
+
+    power_changed = Signal(int, float)   # (led_index, new_power_kw_m2)
+
+    SEGMENTS = 10
+
+    def __init__(self, led_info: LEDInfo, parent=None) -> None:
+        super().__init__(parent)
+        self._index = led_info.index
+        self._max_power = led_info.max_power_kw_m2 or 0.10
+        self._current_power = led_info.power_kw_m2
+        self._output_on = False
+
+        r, g, b = _wavelength_to_rgb(led_info.wavelength_nm)
+        self._color = QColor(r, g, b)
+        self._wavelength = led_info.wavelength_nm
+
+        self._build_ui()
+        self.refresh(led_info, output_on=False)
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(2, 4, 2, 4)
+        layout.setSpacing(2)
+
+        # Wavelength label
+        self._wl_label = QLabel(f"{int(self._wavelength)}")
+        self._wl_label.setAlignment(Qt.AlignCenter)
+        font = QFont()
+        font.setPointSize(7)
+        self._wl_label.setFont(font)
+        layout.addWidget(self._wl_label)
+
+        # Clickable painted segment bar
+        self._bar = _SegmentBar(self._color, self.SEGMENTS)
+        self._bar.clicked.connect(self._on_bar_clicked)
+        layout.addWidget(self._bar, stretch=1)
+
+        # Spinbox for precise control
+        self._spinbox = QDoubleSpinBox()
+        self._spinbox.setDecimals(4)
+        self._spinbox.setRange(0.0, self._max_power)
+        self._spinbox.setSingleStep(0.001)
+        self._spinbox.setValue(self._current_power)
+        self._spinbox.setFixedWidth(72)
+        font2 = QFont()
+        font2.setPointSize(7)
+        self._spinbox.setFont(font2)
+        self._spinbox.valueChanged.connect(self._on_spinbox_changed)
+        layout.addWidget(self._spinbox, alignment=Qt.AlignCenter)
+
+        # LED index label
+        idx_label = QLabel(f"#{self._index}")
+        idx_label.setAlignment(Qt.AlignCenter)
+        idx_label.setFont(font)
+        layout.addWidget(idx_label)
+
+        self.setFixedWidth(80)
+
+    def _on_spinbox_changed(self, value: float) -> None:
+        self._current_power = value
+        self._update_bar()
+        self.power_changed.emit(self._index, value)
+
+    def _on_bar_clicked(self, fraction: float) -> None:
+        self._spinbox.setValue(round(fraction * self._max_power, 4))
+
+    def refresh(self, info: LEDInfo, output_on: bool) -> None:
+        self._output_on = output_on
+        self._max_power = info.max_power_kw_m2 or 0.10
+        self._current_power = info.power_kw_m2
+        self._spinbox.blockSignals(True)
+        self._spinbox.setMaximum(self._max_power)
+        self._spinbox.setValue(self._current_power)
+        self._spinbox.blockSignals(False)
+        self._update_bar()
+
+    def set_output_on(self, on: bool) -> None:
+        self._output_on = on
+        self._update_bar()
+
+    def _update_bar(self) -> None:
+        fraction = (
+            self._current_power / self._max_power if self._max_power > 0 else 0.0
+        )
+        self._bar.set_state(round(fraction * self.SEGMENTS), self._output_on)
+
+
+# ---------------------------------------------------------------------------
+# Connection panel
+# ---------------------------------------------------------------------------
+
+class ConnectionPanel(QGroupBox):
+    connect_requested = Signal(str)
+    disconnect_requested = Signal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__("Connection", parent)
+        layout = QHBoxLayout(self)
+
+        self._resource_combo = QComboBox()
+        self._resource_combo.setEditable(True)
+        self._resource_combo.setPlaceholderText("VISA resource  (blank = auto-detect)")
+        self._resource_combo.setMinimumWidth(280)
+
+        self._scan_btn = QPushButton("Scan")
+        self._scan_btn.setFixedWidth(60)
+        self._scan_btn.clicked.connect(self._scan)
+
+        self._connect_btn = QPushButton("Connect")
+        self._connect_btn.setFixedWidth(80)
+        self._connect_btn.clicked.connect(self._on_connect)
+
+        self._disconnect_btn = QPushButton("Disconnect")
+        self._disconnect_btn.setFixedWidth(90)
+        self._disconnect_btn.setEnabled(False)
+        self._disconnect_btn.clicked.connect(self.disconnect_requested)
+
+        self._idn_label = QLabel("—")
+        self._idn_label.setStyleSheet("color: #888;")
+
+        layout.addWidget(QLabel("Resource:"))
+        layout.addWidget(self._resource_combo)
+        layout.addWidget(self._scan_btn)
+        layout.addWidget(self._connect_btn)
+        layout.addWidget(self._disconnect_btn)
+        layout.addWidget(QLabel("ID:"))
+        layout.addWidget(self._idn_label, stretch=1)
+
+    def _scan(self) -> None:
+        resources = list_instruments()
+        self._resource_combo.clear()
+        if resources:
+            self._resource_combo.addItems(resources)
+        else:
+            self._resource_combo.setPlaceholderText("No USB INSTR found")
+
+    def _on_connect(self) -> None:
+        resource = self._resource_combo.currentText().strip()
+        self.connect_requested.emit(resource)
+
+    def set_connected(self, idn: str) -> None:
+        self._idn_label.setText(idn)
+        self._idn_label.setStyleSheet("color: #2ecc71; font-weight: bold;")
+        self._connect_btn.setEnabled(False)
+        self._disconnect_btn.setEnabled(True)
+
+    def set_disconnected(self) -> None:
+        self._idn_label.setText("—")
+        self._idn_label.setStyleSheet("color: #888;")
+        self._connect_btn.setEnabled(True)
+        self._disconnect_btn.setEnabled(False)
+
+
+# ---------------------------------------------------------------------------
+# Status panel
+# ---------------------------------------------------------------------------
+
+class StatusPanel(QGroupBox):
+    def __init__(self, parent=None) -> None:
+        super().__init__("Instrument Status", parent)
+        layout = QHBoxLayout(self)
+
+        def _indicator(label: str) -> tuple[QLabel, QLabel]:
+            lbl = QLabel(label)
+            dot = QLabel("●")
+            dot.setStyleSheet("color: #555; font-size: 18px;")
+            layout.addWidget(dot)
+            layout.addWidget(lbl)
+            layout.addSpacing(16)
+            return lbl, dot
+
+        _, self._dot_output = _indicator("Output ON")
+        _, self._dot_head = _indicator("Head OK")
+        _, self._dot_warm = _indicator("Warm")
+        _, self._dot_temp = _indicator("Temp OK")
+
+        self._raw_label = QLabel("raw=—")
+        self._raw_label.setStyleSheet("color: #555; font-size: 10px;")
+        layout.addStretch()
+        layout.addWidget(self._raw_label)
+
+        self._apply_disconnected()
+
+    def _apply_disconnected(self) -> None:
+        for dot in (self._dot_output, self._dot_head, self._dot_warm, self._dot_temp):
+            dot.setStyleSheet("color: #555; font-size: 18px;")
+        self._raw_label.setText("raw=—")
+
+    def update_status(self, status: LampStatus) -> None:
+        def _color(ok: bool, true_color: str = "#2ecc71", false_color: str = "#e74c3c") -> str:
+            return true_color if ok else false_color
+
+        self._dot_output.setStyleSheet(
+            f"color: {_color(status.output_on)}; font-size: 18px;"
+        )
+        self._dot_head.setStyleSheet(
+            f"color: {_color(not status.head_disconnected)}; font-size: 18px;"
+        )
+        self._dot_warm.setStyleSheet(
+            f"color: {_color(not status.head_warming_up, '#2ecc71', '#f39c12')}; font-size: 18px;"
+        )
+        self._dot_temp.setStyleSheet(
+            f"color: {_color(not status.head_overtemperature)}; font-size: 18px;"
+        )
+        self._raw_label.setText(f"raw={status.raw}")
+
+    def clear(self) -> None:
+        self._apply_disconnected()
+
+
+# ---------------------------------------------------------------------------
+# Main output control tab
+# ---------------------------------------------------------------------------
+
+class OutputTab(QWidget):
+    output_toggled = Signal(bool)
+    amplitude_set = Signal(float)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setSpacing(16)
+
+        # --- Output on/off ---
+        out_group = QGroupBox("Output")
+        out_layout = QHBoxLayout(out_group)
+
+        self._output_btn = QPushButton("OUTPUT  OFF")
+        self._output_btn.setCheckable(True)
+        self._output_btn.setFixedHeight(52)
+        font = QFont()
+        font.setPointSize(14)
+        font.setBold(True)
+        self._output_btn.setFont(font)
+        self._output_btn.setStyleSheet(
+            "QPushButton { background: #555; color: white; border-radius: 8px; }"
+            "QPushButton:checked { background: #2ecc71; color: black; }"
+        )
+        self._output_btn.toggled.connect(self._on_output_toggled)
+        out_layout.addWidget(self._output_btn)
+        layout.addWidget(out_group)
+
+        # --- Amplitude ---
+        amp_group = QGroupBox("Intensity (Amplitude)")
+        amp_layout = QVBoxLayout(amp_group)
+
+        self._amp_label = QLabel("1.000 sun(s)  =  1.000 kW/m²")
+        self._amp_label.setAlignment(Qt.AlignCenter)
+        font2 = QFont()
+        font2.setPointSize(16)
+        font2.setBold(True)
+        self._amp_label.setFont(font2)
+        amp_layout.addWidget(self._amp_label)
+
+        self._amp_slider = QSlider(Qt.Horizontal)
+        self._amp_slider.setRange(100, 1000)   # 0.100 – 1.000 suns × 1000
+        self._amp_slider.setValue(1000)
+        self._amp_slider.setTickInterval(100)
+        self._amp_slider.setTickPosition(QSlider.TicksBelow)
+        self._amp_slider.valueChanged.connect(self._on_slider_changed)
+        amp_layout.addWidget(self._amp_slider)
+
+        slider_labels = QWidget()
+        sl_layout = QHBoxLayout(slider_labels)
+        sl_layout.setContentsMargins(0, 0, 0, 0)
+        sl_layout.addWidget(QLabel("0.1 sun"))
+        sl_layout.addStretch()
+        sl_layout.addWidget(QLabel("1.0 sun"))
+        amp_layout.addWidget(slider_labels)
+
+        fine_row = QHBoxLayout()
+        fine_row.addWidget(QLabel("Fine:"))
+        self._amp_spin = QDoubleSpinBox()
+        self._amp_spin.setRange(0.100, 1.000)
+        self._amp_spin.setDecimals(3)
+        self._amp_spin.setSingleStep(0.010)
+        self._amp_spin.setValue(1.000)
+        self._amp_spin.setSuffix(" sun(s)")
+        self._amp_spin.valueChanged.connect(self._on_spin_changed)
+        fine_row.addWidget(self._amp_spin)
+        fine_row.addStretch()
+        self._apply_amp_btn = QPushButton("Apply")
+        self._apply_amp_btn.setFixedWidth(80)
+        self._apply_amp_btn.clicked.connect(self._emit_amplitude)
+        fine_row.addWidget(self._apply_amp_btn)
+        amp_layout.addLayout(fine_row)
+
+        layout.addWidget(amp_group)
+        layout.addStretch()
+
+    # ---- internal ----
+
+    def _on_slider_changed(self, value: int) -> None:
+        suns = value / 1000.0
+        self._amp_spin.blockSignals(True)
+        self._amp_spin.setValue(suns)
+        self._amp_spin.blockSignals(False)
+        self._amp_label.setText(f"{suns:.3f} sun(s)  =  {suns:.3f} kW/m²")
+
+    def _on_spin_changed(self, value: float) -> None:
+        self._amp_slider.blockSignals(True)
+        self._amp_slider.setValue(int(round(value * 1000)))
+        self._amp_slider.blockSignals(False)
+        self._amp_label.setText(f"{value:.3f} sun(s)  =  {value:.3f} kW/m²")
+
+    def _on_output_toggled(self, checked: bool) -> None:
+        self._output_btn.setText(f"OUTPUT  {'ON' if checked else 'OFF'}")
+        self.output_toggled.emit(checked)
+
+    def _emit_amplitude(self) -> None:
+        self.amplitude_set.emit(self._amp_spin.value())
+
+    # ---- public setters called from main window ----
+
+    def set_output_state(self, on: bool) -> None:
+        self._output_btn.blockSignals(True)
+        self._output_btn.setChecked(on)
+        self._output_btn.setText(f"OUTPUT  {'ON' if on else 'OFF'}")
+        self._output_btn.blockSignals(False)
+
+    def set_amplitude(self, suns: float) -> None:
+        # If the instrument reports a value above the current widget max (e.g.
+        # after user calibration), expand the range so arrow-up still works.
+        if suns > self._amp_spin.maximum():
+            self._amp_spin.setMaximum(suns)
+            self._amp_slider.setMaximum(int(round(suns * 1000)))
+        self._amp_spin.blockSignals(True)
+        self._amp_slider.blockSignals(True)
+        self._amp_spin.setValue(suns)
+        self._amp_slider.setValue(int(round(suns * 1000)))
+        self._amp_spin.blockSignals(False)
+        self._amp_slider.blockSignals(False)
+        self._amp_label.setText(f"{suns:.3f} sun(s)  =  {suns:.3f} kW/m²")
+
+
+# ---------------------------------------------------------------------------
+# LED spectrum tab
+# ---------------------------------------------------------------------------
+
+class SpectrumTab(QWidget):
+    led_power_changed = Signal(int, float)
+
+    def __init__(self, num_leds: int = 19, parent=None) -> None:
+        super().__init__(parent)
+        self._num_leds = num_leds
+        self._bars: list[LEDBarWidget] = []
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        info = QLabel(
+            "Drag spinboxes to adjust individual LED power (kW/m²). "
+            "Changes are sent to the instrument immediately."
+        )
+        info.setWordWrap(True)
+        info.setStyleSheet("color: #aaa; font-size: 11px;")
+        layout.addWidget(info)
+
+        bar_area = QWidget()
+        bar_layout = QHBoxLayout(bar_area)
+        bar_layout.setSpacing(4)
+        bar_layout.setContentsMargins(4, 4, 4, 4)
+
+        # Placeholder LED infos until we get real data
+        placeholder = [
+            LEDInfo(
+                index=i,
+                wavelength_nm=400 + (i - 1) * 37,
+                power_kw_m2=0.05,
+                max_power_kw_m2=0.10,
+            )
+            for i in range(1, self._num_leds + 1)
+        ]
+        for info_item in placeholder:
+            bar = LEDBarWidget(info_item)
+            bar.power_changed.connect(self.led_power_changed)
+            self._bars.append(bar)
+            bar_layout.addWidget(bar)
+
+        bar_layout.addStretch()
+        layout.addWidget(bar_area)
+
+        # nm axis label
+        nm_label = QLabel("← 400 nm  ·····  visible spectrum  ·····  1100 nm →    (NIR)")
+        nm_label.setAlignment(Qt.AlignCenter)
+        nm_label.setStyleSheet("color: #888; font-size: 10px;")
+        layout.addWidget(nm_label)
+
+    def refresh_leds(self, infos: list, output_on: bool = False) -> None:
+        for info in infos:
+            idx = info.index - 1
+            if 0 <= idx < len(self._bars):
+                self._bars[idx].refresh(info, output_on)
+
+    def set_output_on(self, on: bool) -> None:
+        for bar in self._bars:
+            bar.set_output_on(on)
+
+
+# ---------------------------------------------------------------------------
+# Spectrum memory tab
+# ---------------------------------------------------------------------------
+
+class SpectrumMemoryTab(QWidget):
+    recall_requested = Signal(int)
+    store_requested = Signal(int)
+
+    _LOCATION_LABELS = {
+        0: "0 — Factory AM1.5G (read-only)",
+        1: "1 — Custom (front-panel accessible)",
+        **{i: f"{i} — User slot {i}" for i in range(2, 11)},
+    }
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+
+        # Active spectrum display
+        active_row = QHBoxLayout()
+        active_row.addWidget(QLabel("Active spectrum location:"))
+        self._active_label = QLabel("—")
+        self._active_label.setStyleSheet("font-weight: bold; color: #2ecc71;")
+        active_row.addWidget(self._active_label)
+        active_row.addStretch()
+        layout.addLayout(active_row)
+
+        # Recall
+        recall_group = QGroupBox("Recall Spectrum")
+        recall_layout = QHBoxLayout(recall_group)
+        recall_layout.addWidget(QLabel("Load from location:"))
+        self._recall_combo = QComboBox()
+        for loc, label in self._LOCATION_LABELS.items():
+            self._recall_combo.addItem(label, userData=loc)
+        recall_layout.addWidget(self._recall_combo, stretch=1)
+        recall_btn = QPushButton("Recall")
+        recall_btn.setFixedWidth(80)
+        recall_btn.clicked.connect(self._on_recall)
+        recall_layout.addWidget(recall_btn)
+        layout.addWidget(recall_group)
+
+        # Store
+        store_group = QGroupBox("Store Current Spectrum")
+        store_layout = QHBoxLayout(store_group)
+        store_layout.addWidget(QLabel("Save to location:"))
+        self._store_combo = QComboBox()
+        for loc in range(1, 11):
+            self._store_combo.addItem(self._LOCATION_LABELS[loc], userData=loc)
+        store_layout.addWidget(self._store_combo, stretch=1)
+        store_btn = QPushButton("Store")
+        store_btn.setFixedWidth(80)
+        store_btn.clicked.connect(self._on_store)
+        store_layout.addWidget(store_btn)
+        layout.addWidget(store_group)
+
+        # Quick access
+        quick_group = QGroupBox("Quick Access")
+        quick_layout = QHBoxLayout(quick_group)
+        am15_btn = QPushButton("Recall AM1.5G (slot 0)")
+        am15_btn.clicked.connect(lambda: self.recall_requested.emit(0))
+        custom_btn = QPushButton("Recall Custom (slot 1)")
+        custom_btn.clicked.connect(lambda: self.recall_requested.emit(1))
+        quick_layout.addWidget(am15_btn)
+        quick_layout.addWidget(custom_btn)
+        layout.addWidget(quick_group)
+
+        layout.addStretch()
+
+    def _on_recall(self) -> None:
+        loc = self._recall_combo.currentData()
+        self.recall_requested.emit(loc)
+
+    def _on_store(self) -> None:
+        loc = self._store_combo.currentData()
+        self.store_requested.emit(loc)
+
+    def set_active_location(self, loc: int) -> None:
+        label = self._LOCATION_LABELS.get(loc, str(loc))
+        self._active_label.setText(label)
+
+
+# ---------------------------------------------------------------------------
+# Calibration tab
+# ---------------------------------------------------------------------------
+
+class CalibrationTab(QWidget):
+    cal_mode_changed = Signal(str)
+    perform_cal_requested = Signal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setSpacing(16)
+
+        # Mode selector
+        mode_group = QGroupBox("Intensity Calibration Mode")
+        mode_layout = QHBoxLayout(mode_group)
+        mode_layout.addWidget(QLabel("Active mode:"))
+        self._mode_combo = QComboBox()
+        self._mode_combo.addItem("Factory Default (DEFAULT)", userData="DEFAULT")
+        self._mode_combo.addItem("User Offset (USER)", userData="USER")
+        self._mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+        mode_layout.addWidget(self._mode_combo)
+        mode_layout.addStretch()
+        layout.addWidget(mode_group)
+
+        # User cal
+        usercal_group = QGroupBox("Perform User Calibration")
+        usercal_layout = QVBoxLayout(usercal_group)
+        desc = QLabel(
+            "Place your reference sample under the head, adjust the output until "
+            "your meter reads 1.00 sun, then press the button below. The controller "
+            "will rescale its display to 1.00 sun at the current set point."
+        )
+        desc.setWordWrap(True)
+        usercal_layout.addWidget(desc)
+        self._perform_btn = QPushButton("Execute User Calibration  (USERCAL:PERFORM)")
+        self._perform_btn.setFixedHeight(40)
+        self._perform_btn.clicked.connect(self.perform_cal_requested)
+        usercal_layout.addWidget(self._perform_btn)
+        layout.addWidget(usercal_group)
+
+        layout.addStretch()
+
+    def _on_mode_changed(self) -> None:
+        self.cal_mode_changed.emit(self._mode_combo.currentData())
+
+    def set_calibration_mode(self, mode_str: str) -> None:
+        self._mode_combo.blockSignals(True)
+        for i in range(self._mode_combo.count()):
+            if self._mode_combo.itemData(i) == mode_str:
+                self._mode_combo.setCurrentIndex(i)
+                break
+        self._mode_combo.blockSignals(False)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics tab
+# ---------------------------------------------------------------------------
+
+class DiagnosticsTab(QWidget):
+    fetch_errors_requested = Signal()
+    led_test_requested = Signal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+
+        # Error queue
+        err_group = QGroupBox("Instrument Error Queue")
+        err_layout = QVBoxLayout(err_group)
+        self._errors_text = QTextEdit()
+        self._errors_text.setReadOnly(True)
+        self._errors_text.setMaximumHeight(100)
+        self._errors_text.setPlaceholderText("Press 'Fetch Errors' to query the error queue…")
+        err_layout.addWidget(self._errors_text)
+        fetch_btn = QPushButton("Fetch Errors  (ERROR?)")
+        fetch_btn.clicked.connect(self.fetch_errors_requested)
+        err_layout.addWidget(fetch_btn)
+        layout.addWidget(err_group)
+
+        # LED self-test
+        test_group = QGroupBox("LED Self-Test  (LEDTEST:POWER?)")
+        test_layout = QVBoxLayout(test_group)
+        note = QLabel(
+            "The self-test cycles through all LEDs, measuring power at each wavelength. "
+            "This takes ~60 seconds. Do not adjust settings during the test."
+        )
+        note.setWordWrap(True)
+        test_layout.addWidget(note)
+
+        self._test_btn = QPushButton("Run LED Self-Test")
+        self._test_btn.clicked.connect(self._on_run_test)
+        test_layout.addWidget(self._test_btn)
+
+        self._test_progress = QProgressBar()
+        self._test_progress.setVisible(False)
+        test_layout.addWidget(self._test_progress)
+
+        self._test_result_label = QLabel("")
+        test_layout.addWidget(self._test_result_label)
+
+        # Results table
+        self._results_table = QTableWidget(0, 4)
+        self._results_table.setHorizontalHeaderLabels(
+            ["LED #", "Wavelength (nm)", "User Power (kW/m²)", "Factory Power (kW/m²)"]
+        )
+        self._results_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self._results_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        test_layout.addWidget(self._results_table)
+        layout.addWidget(test_group)
+
+    def _on_run_test(self) -> None:
+        self._test_btn.setEnabled(False)
+        self._test_progress.setVisible(True)
+        self._test_progress.setRange(0, 0)   # indeterminate
+        self._test_result_label.setText("Running…")
+        self.led_test_requested.emit()
+
+    def show_errors(self, errors: list[str]) -> None:
+        if errors:
+            self._errors_text.setPlainText("\n".join(errors))
+            self._errors_text.setStyleSheet("color: #e74c3c;")
+        else:
+            self._errors_text.setPlainText("No errors.")
+            self._errors_text.setStyleSheet("color: #2ecc71;")
+
+    def show_test_results(self, passed: bool, results: list) -> None:
+        self._test_btn.setEnabled(True)
+        self._test_progress.setVisible(False)
+        status = "✓ PASSED" if passed else "✗ FAILED"
+        color = "#2ecc71" if passed else "#e74c3c"
+        self._test_result_label.setText(f"Result: {status}")
+        self._test_result_label.setStyleSheet(f"color: {color}; font-weight: bold;")
+
+        self._results_table.setRowCount(len(results))
+        for row, item in enumerate(results):
+            led_idx, user_p, factory_p = item
+            self._results_table.setItem(row, 0, QTableWidgetItem(str(led_idx)))
+            # Wavelength not available here; would need a separate query
+            self._results_table.setItem(row, 1, QTableWidgetItem("—"))
+            up = f"{user_p:.4f}" if user_p is not None else "—"
+            fp = f"{factory_p:.4f}" if factory_p is not None else "—"
+            self._results_table.setItem(row, 2, QTableWidgetItem(up))
+            self._results_table.setItem(row, 3, QTableWidgetItem(fp))
+            # Colour rows where user < factory
+            if user_p is not None and factory_p is not None and user_p < factory_p * 0.95:
+                for col in range(4):
+                    cell = self._results_table.item(row, col)
+                    if cell:
+                        cell.setBackground(QColor(80, 30, 30))
+
+
+# ---------------------------------------------------------------------------
+# Activity log panel
+# ---------------------------------------------------------------------------
+
+class LogPanel(QGroupBox):
+    def __init__(self, parent=None) -> None:
+        super().__init__("Activity Log", parent)
+        layout = QVBoxLayout(self)
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setMaximumHeight(130)
+        font = QFont("Courier", 9)
+        self._log.setFont(font)
+        layout.addWidget(self._log)
+        clear_btn = QPushButton("Clear")
+        clear_btn.setFixedWidth(60)
+        clear_btn.clicked.connect(self._log.clear)
+        h = QHBoxLayout()
+        h.addStretch()
+        h.addWidget(clear_btn)
+        layout.addLayout(h)
+
+    def append(self, msg: str) -> None:
+        self._log.append(msg)
+        self._log.verticalScrollBar().setValue(
+            self._log.verticalScrollBar().maximum()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main window
+# ---------------------------------------------------------------------------
+
+class MainWindow(QMainWindow):
+    # Signals sent to the worker (must be defined at class level)
+    _sig_connect = Signal(str)
+    _sig_disconnect = Signal()
+    _sig_set_output = Signal(bool)
+    _sig_set_amplitude = Signal(float)
+    _sig_set_led_power = Signal(int, float)
+    _sig_refresh_leds = Signal()
+    _sig_recall_spectrum = Signal(int)
+    _sig_store_spectrum = Signal(int)
+    _sig_set_cal_mode = Signal(str)
+    _sig_perform_cal = Signal()
+    _sig_fetch_errors = Signal()
+    _sig_run_led_test = Signal()
+    _sig_poll_status = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("VeraSol LSS-7120 — LED Solar Simulator Control Panel")
+        self.setMinimumSize(1100, 720)
+
+        self._connected = False
+        self._output_on = False
+
+        self._build_ui()
+        self._setup_worker()
+        self._setup_poll_timer()
+
+        if not DRIVER_AVAILABLE:
+            self._log.append(
+                f"[WARNING] verasol driver not available: {_IMPORT_ERROR}\n"
+                "Running in stub mode — UI layout only."
+            )
+
+    # ---- UI construction ----
+
+    def _build_ui(self) -> None:
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+        root.setSpacing(8)
+
+        # Connection bar
+        self._conn_panel = ConnectionPanel()
+        self._conn_panel.connect_requested.connect(self._on_connect_requested)
+        self._conn_panel.disconnect_requested.connect(self._on_disconnect_requested)
+        root.addWidget(self._conn_panel)
+
+        # Status bar
+        self._status_panel = StatusPanel()
+        root.addWidget(self._status_panel)
+
+        # Tab area
+        self._tabs = QTabWidget()
+        self._tabs.setEnabled(False)   # disabled until connected
+
+        self._output_tab = OutputTab()
+        self._output_tab.output_toggled.connect(self._on_output_toggled)
+        self._output_tab.amplitude_set.connect(self._on_amplitude_set)
+        self._tabs.addTab(self._output_tab, "⚡ Output")
+
+        self._spectrum_tab = SpectrumTab(num_leds=VeraSol.NUM_LEDS)
+        self._spectrum_tab.led_power_changed.connect(self._on_led_power_changed)
+        self._tabs.addTab(self._spectrum_tab, "🌈 LED Spectrum")
+
+        self._mem_tab = SpectrumMemoryTab()
+        self._mem_tab.recall_requested.connect(self._sig_recall_spectrum)
+        self._mem_tab.store_requested.connect(self._sig_store_spectrum)
+        self._tabs.addTab(self._mem_tab, "💾 Spectrum Memory")
+
+        self._cal_tab = CalibrationTab()
+        self._cal_tab.cal_mode_changed.connect(self._sig_set_cal_mode)
+        self._cal_tab.perform_cal_requested.connect(self._sig_perform_cal)
+        self._tabs.addTab(self._cal_tab, "🔧 Calibration")
+
+        self._diag_tab = DiagnosticsTab()
+        self._diag_tab.fetch_errors_requested.connect(self._sig_fetch_errors)
+        self._diag_tab.led_test_requested.connect(self._sig_run_led_test)
+        self._tabs.addTab(self._diag_tab, "🔬 Diagnostics")
+
+        root.addWidget(self._tabs, stretch=1)
+
+        # Log panel
+        self._log = LogPanel()
+        root.addWidget(self._log)
+
+        # Status bar
+        self._statusbar = QStatusBar()
+        self.setStatusBar(self._statusbar)
+        self._statusbar.showMessage("Not connected.")
+
+        self._apply_dark_theme()
+
+    def _apply_dark_theme(self) -> None:
+        self.setStyleSheet("""
+            QMainWindow, QWidget {
+                background-color: #1e1e2e;
+                color: #cdd6f4;
+            }
+            QGroupBox {
+                border: 1px solid #45475a;
+                border-radius: 6px;
+                margin-top: 10px;
+                padding-top: 6px;
+                font-weight: bold;
+            }
+            QGroupBox::title {
+                subcontrol-origin: margin;
+                left: 10px;
+                color: #89b4fa;
+            }
+            QTabWidget::pane {
+                border: 1px solid #45475a;
+                border-radius: 4px;
+            }
+            QTabBar::tab {
+                background: #313244;
+                color: #cdd6f4;
+                padding: 6px 14px;
+                margin-right: 2px;
+                border-radius: 4px 4px 0 0;
+            }
+            QTabBar::tab:selected {
+                background: #45475a;
+                color: #cba6f7;
+                font-weight: bold;
+            }
+            QPushButton {
+                background-color: #313244;
+                color: #cdd6f4;
+                border: 1px solid #45475a;
+                border-radius: 4px;
+                padding: 4px 10px;
+            }
+            QPushButton:hover { background-color: #45475a; }
+            QPushButton:pressed { background-color: #585b70; }
+            QPushButton:disabled { color: #585b70; }
+            QSlider::groove:horizontal {
+                height: 8px;
+                background: #313244;
+                border-radius: 4px;
+            }
+            QSlider::handle:horizontal {
+                background: #89b4fa;
+                border: none;
+                width: 18px;
+                height: 18px;
+                margin: -5px 0;
+                border-radius: 9px;
+            }
+            QSlider::sub-page:horizontal { background: #89b4fa; border-radius: 4px; }
+            QDoubleSpinBox, QSpinBox, QComboBox, QTextEdit {
+                background-color: #313244;
+                color: #cdd6f4;
+                border: 1px solid #45475a;
+                border-radius: 4px;
+                padding: 2px 4px;
+            }
+            QTableWidget {
+                background-color: #181825;
+                gridline-color: #45475a;
+            }
+            QHeaderView::section {
+                background-color: #313244;
+                color: #89b4fa;
+                border: none;
+                padding: 4px;
+            }
+            QProgressBar {
+                background: #313244;
+                border: 1px solid #45475a;
+                border-radius: 4px;
+                text-align: center;
+            }
+            QProgressBar::chunk { background: #89b4fa; border-radius: 4px; }
+        """)
+
+    # ---- Worker / thread setup ----
+
+    def _setup_worker(self) -> None:
+        self._thread = QThread()
+        self._worker = InstrumentWorker()
+        self._worker.moveToThread(self._thread)
+        self._thread.start()
+
+        # Wire signals → worker slots
+        self._sig_connect.connect(self._worker.connect)
+        self._sig_disconnect.connect(self._worker.disconnect)
+        self._sig_set_output.connect(self._worker.set_output)
+        self._sig_set_amplitude.connect(self._worker.set_amplitude)
+        self._sig_set_led_power.connect(self._worker.set_led_power)
+        self._sig_refresh_leds.connect(self._worker.refresh_leds)
+        self._sig_recall_spectrum.connect(self._worker.recall_spectrum)
+        self._sig_store_spectrum.connect(self._worker.store_spectrum)
+        self._sig_set_cal_mode.connect(self._worker.set_calibration_mode)
+        self._sig_perform_cal.connect(self._worker.perform_user_cal)
+        self._sig_fetch_errors.connect(self._worker.fetch_errors)
+        self._sig_run_led_test.connect(self._worker.run_led_test)
+        self._sig_poll_status.connect(self._worker.poll_status)
+
+        # Wire worker signals → GUI slots
+        self._worker.connected.connect(self._on_connected)
+        self._worker.disconnected.connect(self._on_disconnected)
+        self._worker.error.connect(self._on_error)
+        self._worker.log_message.connect(self._log.append)
+        self._worker.status_updated.connect(self._on_status_updated)
+        self._worker.amplitude_updated.connect(self._output_tab.set_amplitude)
+        self._worker.output_updated.connect(self._on_output_updated)
+        self._worker.led_info_updated.connect(self._on_led_info_updated)
+        self._worker.spectrum_location_updated.connect(self._mem_tab.set_active_location)
+        self._worker.calibration_mode_updated.connect(self._cal_tab.set_calibration_mode)
+        self._worker.errors_received.connect(self._diag_tab.show_errors)
+        self._worker.led_test_finished.connect(self._diag_tab.show_test_results)
+
+    def _setup_poll_timer(self) -> None:
+        self._poll_timer = QTimer(self)
+        self._poll_timer.setInterval(2000)   # 2-second status poll
+        self._poll_timer.timeout.connect(self._sig_poll_status)
+
+    # ---- Slots: connection ----
+
+    def _on_connect_requested(self, resource: str) -> None:
+        self._statusbar.showMessage("Connecting…")
+        self._sig_connect.emit(resource)
+
+    def _on_disconnect_requested(self) -> None:
+        self._poll_timer.stop()
+        self._sig_disconnect.emit()
+
+    @Slot(str)
+    def _on_connected(self, idn: str) -> None:
+        self._connected = True
+        self._conn_panel.set_connected(idn)
+        self._tabs.setEnabled(True)
+        self._poll_timer.start()
+        self._statusbar.showMessage(f"Connected — {idn}")
+
+    @Slot()
+    def _on_disconnected(self) -> None:
+        self._connected = False
+        self._conn_panel.set_disconnected()
+        self._tabs.setEnabled(False)
+        self._status_panel.clear()
+        self._statusbar.showMessage("Disconnected.")
+
+    # ---- Slots: instrument events ----
+
+    @Slot(str)
+    def _on_error(self, msg: str) -> None:
+        self._log.append(f"[ERROR] {msg}")
+        self._statusbar.showMessage(f"Error: {msg}", 5000)
+
+    @Slot(object)
+    def _on_status_updated(self, status: LampStatus) -> None:
+        self._status_panel.update_status(status)
+        # Sync output button state without re-sending the command
+        if status.output_on != self._output_on:
+            self._output_on = status.output_on
+            self._output_tab.set_output_state(self._output_on)
+            self._spectrum_tab.set_output_on(self._output_on)
+        # Warn if head is over-temperature
+        if status.head_overtemperature:
+            self._statusbar.showMessage("⚠  Head over-temperature!", 4000)
+        elif status.head_disconnected:
+            self._statusbar.showMessage("⚠  Head disconnected — check CC720 cable", 4000)
+
+    @Slot(bool)
+    def _on_output_updated(self, on: bool) -> None:
+        self._output_on = on
+        self._output_tab.set_output_state(on)
+        self._spectrum_tab.set_output_on(on)
+
+    @Slot(list)
+    def _on_led_info_updated(self, infos: list) -> None:
+        self._spectrum_tab.refresh_leds(infos, output_on=self._output_on)
+
+    # ---- Slots: user actions ----
+
+    def _on_output_toggled(self, on: bool) -> None:
+        self._sig_set_output.emit(on)
+
+    def _on_amplitude_set(self, suns: float) -> None:
+        self._sig_set_amplitude.emit(suns)
+
+    def _on_led_power_changed(self, led: int, power: float) -> None:
+        self._sig_set_led_power.emit(led, power)
+
+    # ---- Cleanup ----
+
+    def closeEvent(self, event) -> None:
+        self._poll_timer.stop()
+        if self._connected:
+            self._sig_disconnect.emit()
+        self._thread.quit()
+        self._thread.wait(3000)
+        event.accept()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setApplicationName("VeraSol Control Panel")
+    app.setOrganizationName("Oriel Instruments / EPFL-LPI")
+
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/iv_lab/config/settings.py
+++ b/src/iv_lab/config/settings.py
@@ -83,7 +83,10 @@ class LampSettings(LegacyCompatibleModel):
             self.display_name = f"{self.brand} {self.model}"
         # Legacy lamp.__init__ reads lightLevelDict for every brand except
         # 'manual' (case-sensitive comparison, as in the legacy code).
-        if self.brand != "manual" and self.lightLevelDict is None:
+        # 'VeraSol' also skips the requirement: it accepts continuous amplitude
+        # directly from light_int and does not need a lookup table.
+        _no_dict_brands = {"manual", "verasol"}
+        if self.brand.lower() not in _no_dict_brands and self.lightLevelDict is None:
             raise ValueError(
                 f"lamp brand {self.brand!r} requires a 'lightLevelDict' entry"
             )
@@ -102,6 +105,16 @@ class SMUSettings(LegacyCompatibleModel):
     autorange: bool = True
     measSpeed: str = "normal"
     useReferenceDiode: bool = True
+    #: Serial (RS-232 / ``ASRL``) connection parameters.  Ignored for GPIB/USB
+    #: addresses, where termination is handled by the bus (EOI).  For a serial
+    #: Keithley these must match the instrument's front-panel RS-232 settings,
+    #: or every read hangs until the VISA timeout.  ``None`` means "use the
+    #: driver default" (see ``keithley_2400.py``).
+    baud_rate: Optional[int] = None
+    read_termination: Optional[str] = None
+    write_termination: Optional[str] = None
+    #: VISA read timeout in milliseconds (applies to all interface types).
+    timeout_ms: Optional[float] = None
 
 
 class ArduinoSettings(LegacyCompatibleModel):

--- a/src/iv_lab/hardware/lamp/drivers/__init__.py
+++ b/src/iv_lab/hardware/lamp/drivers/__init__.py
@@ -12,4 +12,5 @@ from . import keithley_filter  # noqa: F401
 from . import manual  # noqa: F401
 from . import oriel  # noqa: F401
 from . import trinamic  # noqa: F401
+from . import verasol  # noqa: F401
 from . import wavelabs  # noqa: F401

--- a/src/iv_lab/hardware/lamp/drivers/_verasol_lib.py
+++ b/src/iv_lab/hardware/lamp/drivers/_verasol_lib.py
@@ -1,0 +1,574 @@
+"""
+_verasol_lib.py — Low-level control library for the Oriel VeraSol LSS-7120 LED Solar Simulator.
+
+Copied verbatim from docs/verasol/verasol.py.  Do not import this module at
+package load time — it imports pyvisa at module level.  Only import it inside
+``_open()`` or equivalent connection-time methods.
+
+Communication is over USB via the USBTMC (USB Test and Measurement Class) protocol.
+Requires a VISA backend: install with `pip install pyvisa pyvisa-py` (or use NI-VISA).
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import time
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+try:
+    import pyvisa
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "pyvisa is required: pip install pyvisa pyvisa-py"
+    ) from exc
+
+# Windows-only imports for the IVI USBTMC fallback transport
+if sys.platform == "win32":
+    import ctypes
+    import winreg
+    from ctypes import windll, create_string_buffer, c_ulong, byref as _byref
+    _WIN32_AVAILABLE = True
+else:
+    _WIN32_AVAILABLE = False
+
+# Device interface GUID assigned by the Windows IVI USBTMC class driver
+_WIN32_USBTMC_GUID = "{a9fdbb24-128a-11d5-9961-00108335e361}"
+# Substring present in the IDN string of every VeraSol instrument
+_VERASOL_IDN_HINT = "LSS-7120"
+
+
+# ---------------------------------------------------------------------------
+# Public data types
+# ---------------------------------------------------------------------------
+
+class SpectrumMode(str, Enum):
+    """Named spectrum slots understood by the controller."""
+    AM15G = "AM1.5G"   # Factory AM1.5G (memory location 0)
+    CUSTOM = "CUSTOM"  # Custom / user-defined (memory location 1, front-panel)
+
+
+class CalibrationMode(str, Enum):
+    DEFAULT = "DEFAULT"  # Factory calibration
+    USER = "USER"        # User intensity offset
+
+
+@dataclass
+class LampStatus:
+    """Decoded STATUS? response (bit-field, see manual p. 30)."""
+    output_on: bool
+    head_disconnected: bool
+    head_warming_up: bool
+    head_overtemperature: bool
+    raw: int
+
+    def __str__(self) -> str:
+        flags = []
+        if self.output_on:
+            flags.append("OUTPUT=ON")
+        if self.head_disconnected:
+            flags.append("HEAD_DISCONNECTED")
+        if self.head_warming_up:
+            flags.append("WARMING_UP")
+        if self.head_overtemperature:
+            flags.append("OVERTEMP")
+        return f"LampStatus({', '.join(flags) or 'OK'})"
+
+
+@dataclass
+class LEDInfo:
+    """Power and wavelength information for a single LED channel."""
+    index: int           # 1-based LED number (1-24)
+    wavelength_nm: float
+    power_kw_m2: float
+    max_power_kw_m2: float
+
+
+# ---------------------------------------------------------------------------
+# Windows IVI USBTMC fallback transport
+# ---------------------------------------------------------------------------
+
+class _WinUSBTMC:
+    """
+    Minimal USBTMC transport that talks to the Windows IVI USBTMC class driver
+    directly via Win32 file handles, bypassing NI-VISA's device enumeration.
+
+    Implements the write / read / query / close / timeout interface that
+    VeraSol expects from a pyvisa Resource object.
+    """
+
+    _GENERIC_RW    = 0x80000000 | 0x40000000   # GENERIC_READ | GENERIC_WRITE
+    _FILE_SHARE_RW = 0x01 | 0x02               # FILE_SHARE_READ | FILE_SHARE_WRITE
+    _OPEN_EXISTING = 3
+
+    def __init__(self, path: str, timeout_ms: int = 10_000) -> None:
+        if not _WIN32_AVAILABLE:
+            raise OSError("_WinUSBTMC is only supported on Windows.")
+        self.timeout           = timeout_ms   # stored; used by run_led_test()
+        self.read_termination  = "\n"
+        self.write_termination = "\n"
+        self._btag = 0
+        self._h = windll.kernel32.CreateFileW(
+            path, self._GENERIC_RW, self._FILE_SHARE_RW,
+            None, self._OPEN_EXISTING, 0, None,
+        )
+        if self._h == -1:
+            raise OSError(
+                f"Cannot open USBTMC device (err={ctypes.GetLastError()}): {path}"
+            )
+
+    def close(self) -> None:
+        if self._h not in (None, -1):
+            windll.kernel32.CloseHandle(self._h)
+            self._h = None
+
+    def _next_tag(self) -> int:
+        self._btag = (self._btag % 255) + 1
+        return self._btag
+
+    def write(self, msg: str) -> None:
+        data = (msg.rstrip("\n") + self.write_termination).encode()
+        tag  = self._next_tag()
+        header = struct.pack(
+            "<BBBBIBxxx",
+            0x01, tag, (~tag) & 0xFF, 0,   # DEV_DEP_MSG_OUT, bTag, ~bTag, reserved
+            len(data), 0x01,               # TransferSize, bmTransferAttributes (EOM)
+        )
+        packet = header + data
+        packet += b"\x00" * ((4 - len(packet) % 4) % 4)   # 4-byte alignment padding
+        buf     = create_string_buffer(packet)
+        written = c_ulong(0)
+        if not windll.kernel32.WriteFile(self._h, buf, len(packet), _byref(written), None):
+            raise OSError(f"USBTMC WriteFile failed: {ctypes.GetLastError()}")
+
+    def read(self) -> str:
+        tag = self._next_tag()
+        req = struct.pack(
+            "<BBBBIBxxx",
+            0x02, tag, (~tag) & 0xFF, 0,   # REQUEST_DEV_DEP_MSG_IN
+            4096, 0x00,                    # TransferSize, bmTransferAttributes
+        )
+        buf_req = create_string_buffer(req)
+        written = c_ulong(0)
+        windll.kernel32.WriteFile(self._h, buf_req, len(req), _byref(written), None)
+        buf_resp  = create_string_buffer(4096 + 12)
+        read_bytes = c_ulong(0)
+        if not windll.kernel32.ReadFile(
+            self._h, buf_resp, 4096 + 12, _byref(read_bytes), None
+        ):
+            raise OSError(f"USBTMC ReadFile failed: {ctypes.GetLastError()}")
+        n = read_bytes.value
+        if n < 12:
+            return ""
+        payload_len = struct.unpack_from("<I", buf_resp.raw, 4)[0]
+        # A 0-byte payload with EOM set is the device's command acknowledgement.
+        # NI-VISA translates this to the string "Ready"; we do the same so that
+        # VeraSol._write() can check for it without knowing which transport is used.
+        if payload_len == 0 and (buf_resp.raw[8] & 0x01):
+            return "Ready"
+        raw = buf_resp.raw[12 : 12 + payload_len].decode("ascii", errors="replace")
+        return raw.rstrip(self.read_termination or "\n")
+
+    def query(self, msg: str) -> str:
+        self.write(msg)
+        return self.read()
+
+
+def _find_win_usbtmc_device(idn_hint: str = _VERASOL_IDN_HINT) -> Optional[str]:
+    """
+    Search the Windows device-interface registry for a USBTMC instrument whose
+    ``*IDN?`` response contains *idn_hint*.  Returns the Win32 device path on
+    success, or *None* if no matching instrument is found.
+    """
+    if not _WIN32_AVAILABLE:
+        return None
+    key_path = (
+        r"SYSTEM\CurrentControlSet\Control\DeviceClasses"
+        rf"\{_WIN32_USBTMC_GUID}"
+    )
+    try:
+        root = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path)
+    except FileNotFoundError:
+        return None
+    i = 0
+    while True:
+        try:
+            dev_key_name = winreg.EnumKey(root, i)
+        except OSError:
+            break
+        i += 1
+        # Registry key names use ##?# prefix; Win32 paths use \\?\
+        device_path = "\\\\?\\" + dev_key_name[4:]
+        try:
+            instr = _WinUSBTMC(device_path)
+            idn   = instr.query("*IDN?")
+            instr.close()
+            if idn_hint in idn:
+                return device_path
+        except Exception:
+            pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main driver class
+# ---------------------------------------------------------------------------
+
+class VeraSol:
+    """
+    Driver for the Oriel VeraSol LSS-7120 LED Solar Simulator Controller.
+
+    Parameters
+    ----------
+    resource_name:
+        VISA resource string, e.g. ``"USB0::0x1028::0x0001::71201234::INSTR"``.
+        When *None* (default) the driver opens the first matching USB instrument.
+    timeout_ms:
+        VISA read/write timeout in milliseconds (default 10 000 ms).
+
+    Can be used as a context manager::
+
+        with VeraSol() as lamp:
+            lamp.set_amplitude(0.5)
+    """
+
+    # Default VISA identifier substring used for auto-discovery
+    _ID_QUERY_HINT = "LSS-7120"
+    # Number of individually addressable LED channels
+    NUM_LEDS = 19
+
+    def __init__(
+        self,
+        resource_name: Optional[str] = None,
+        timeout_ms: int = 10_000,
+    ) -> None:
+        self._rm = None
+
+        # Direct Windows IVI USBTMC path — bypass pyvisa entirely
+        if resource_name and resource_name.startswith("\\\\?\\"):
+            self._resource_name = resource_name
+            self._instr = _WinUSBTMC(resource_name, timeout_ms)
+            return
+
+        # Primary path: use pyvisa (NI-VISA or pyvisa-py)
+        try:
+            self._rm = pyvisa.ResourceManager()
+            self._resource_name = resource_name or self._find_resource()
+            self._instr = self._rm.open_resource(self._resource_name)
+            self._instr.timeout = timeout_ms
+            # The VeraSol acknowledges write commands with a 0-byte USB END
+            # (EOM) message, not a text character.  Setting read_termination=""
+            # disables NI-VISA's VI_ATTR_TERMCHAR_EN so reads terminate on the
+            # USB END bit rather than waiting for "\n" (which never arrives).
+            self._instr.read_termination  = ""
+            self._instr.write_termination = "\n"
+            return
+        except (RuntimeError, pyvisa.errors.VisaIOError):
+            if self._rm is not None:
+                try:
+                    self._rm.close()
+                except Exception:
+                    pass
+                self._rm = None
+
+        # Fallback: Windows IVI USBTMC class driver (auto-discover)
+        win_path = _find_win_usbtmc_device()
+        if win_path is None:
+            raise RuntimeError(
+                "No VeraSol instrument found via VISA or the Windows IVI USBTMC "
+                "driver.  Check the USB cable and VISA driver installation."
+            )
+        self._resource_name = win_path
+        self._instr = _WinUSBTMC(win_path, timeout_ms)
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "VeraSol":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Release the VISA resource."""
+        try:
+            self._instr.close()
+        finally:
+            if self._rm is not None:
+                self._rm.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _find_resource(self) -> str:
+        """Return the first USB resource that identifies as an LSS-7120."""
+        resources = self._rm.list_resources("USB?*INSTR")
+        if not resources:
+            raise RuntimeError(
+                "No USB INSTR resources found. Check the USB cable and VISA drivers."
+            )
+        for name in resources:
+            try:
+                instr = self._rm.open_resource(name)
+                idn = instr.query("*IDN?").strip()
+                instr.close()
+                if self._ID_QUERY_HINT in idn:
+                    return name
+            except Exception:
+                pass
+        # Fall back to the first resource and let the user sort it out
+        return resources[0]
+
+    def _write(self, cmd: str) -> None:
+        """Send a command and consume the mandatory 'Ready' acknowledgement.
+
+        The VeraSol sends a 0-byte USB message with the EOM bit as its
+        acknowledgement.  _WinUSBTMC translates that to the string "Ready";
+        NI-VISA (via pyvisa) returns it as an empty string.  Both are valid.
+        """
+        self._instr.write(cmd)
+        # Suppress pyvisa UserWarning: response arrives via USB END bit, not \n.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            ack = self._instr.read().strip()
+        # "" = NI-VISA encoding of 0-byte EOM ack; "ready" = _WinUSBTMC encoding.
+        if ack and ack.lower() != "ready":
+            raise RuntimeError(
+                f"Unexpected acknowledgement for command '{cmd!r}': {ack!r}"
+            )
+
+    def _query(self, cmd: str) -> str:
+        """Send a query and return the stripped response string."""
+        return self._instr.query(cmd).strip()
+
+    # ------------------------------------------------------------------
+    # Identification
+    # ------------------------------------------------------------------
+
+    def identify(self) -> str:
+        """Return the instrument identification string.
+
+        Example: ``"Newport Corporation,LSS-7120,71201234,1.01"``
+        """
+        return self._query("*IDN?")
+
+    # ------------------------------------------------------------------
+    # Output control
+    # ------------------------------------------------------------------
+
+    def set_output(self, on: bool) -> None:
+        """Turn the LED output on (``True``) or off (``False``)."""
+        self._write(f"OUTPUT {'ON' if on else 'OFF'}")
+
+    def get_output(self) -> bool:
+        """Return *True* if the LED output is currently on."""
+        response = self._query("OUTPUT?")
+        return response.strip().upper() in ("ON", "1")
+
+    # ------------------------------------------------------------------
+    # Amplitude / intensity
+    # ------------------------------------------------------------------
+
+    def set_amplitude(self, suns: float) -> None:
+        """Set the output intensity.
+
+        Parameters
+        ----------
+        suns:
+            Target irradiance in suns (0.1 – 1.0).  1.0 sun = 1 kW m⁻².
+        """
+        if suns < 0.1:
+            raise ValueError(f"Amplitude must be ≥ 0.1 suns, got {suns}.")
+        self._write(f"AMPLITUDE {suns:.3f}")
+
+    def get_amplitude(self) -> float:
+        """Return the current output amplitude in suns."""
+        return float(self._query("AMPLITUDE?"))
+
+    # ------------------------------------------------------------------
+    # Individual LED power
+    # ------------------------------------------------------------------
+
+    def set_led_power(self, led: int, power_kw_m2: float) -> None:
+        """Set the output power of a single LED channel."""
+        self._validate_led_index(led)
+        self._write(f"LEDPOWER {led},{power_kw_m2:.4f}")
+
+    def get_led_power(self, led: int) -> float:
+        """Return the current power set-point of *led* in kW m⁻²."""
+        self._validate_led_index(led)
+        return float(self._query(f"LEDPOWER? {led}"))
+
+    def get_led_max_power(self, led: int) -> float:
+        """Return the maximum allowed power of *led* in kW m⁻²."""
+        self._validate_led_index(led)
+        return float(self._query(f"LEDMAXPOWER? {led}"))
+
+    def get_led_wavelength(self, led: int) -> float:
+        """Return the peak wavelength of *led* in nm."""
+        self._validate_led_index(led)
+        return float(self._query(f"LEDWAVELENGTH? {led}"))
+
+    def get_led_info(self, led: int) -> LEDInfo:
+        """Return a :class:`LEDInfo` summary for *led*."""
+        return LEDInfo(
+            index=led,
+            wavelength_nm=self.get_led_wavelength(led),
+            power_kw_m2=self.get_led_power(led),
+            max_power_kw_m2=self.get_led_max_power(led),
+        )
+
+    def get_all_led_info(self) -> list[LEDInfo]:
+        """Return :class:`LEDInfo` for every LED channel (1 – NUM_LEDS)."""
+        return [self.get_led_info(i) for i in range(1, self.NUM_LEDS + 1)]
+
+    @staticmethod
+    def _validate_led_index(led: int) -> None:
+        if not (1 <= led <= 24):
+            raise ValueError(f"LED index must be 1-24, got {led}.")
+
+    # ------------------------------------------------------------------
+    # Spectrum management
+    # ------------------------------------------------------------------
+
+    def store_spectrum(self, location: int) -> None:
+        """Store the current LED spectrum to a memory slot (1–10)."""
+        if not (1 <= location <= 10):
+            raise ValueError(f"Storage location must be 1-10, got {location}.")
+        self._write(f"SPECTRUM:STORE {location}")
+
+    def recall_spectrum(self, location: int) -> None:
+        """Recall a previously stored spectrum (0=AM1.5G, 1=custom, 2–10=user)."""
+        if not (0 <= location <= 10):
+            raise ValueError(f"Storage location must be 0-10, got {location}.")
+        self._write(f"SPECTRUM:RECALL {location}")
+
+    def get_active_spectrum_location(self) -> int:
+        """Return the memory-location number of the currently active spectrum."""
+        return int(self._query("SPECTRUM:ACTIVE?"))
+
+    # ------------------------------------------------------------------
+    # Calibration
+    # ------------------------------------------------------------------
+
+    def set_calibration_mode(self, mode: CalibrationMode) -> None:
+        """Select factory (*DEFAULT*) or user-offset (*USER*) intensity calibration."""
+        value = 0 if mode == CalibrationMode.DEFAULT else 1
+        self._write(f"USERCAL:SELECT {value}")
+
+    def get_calibration_mode(self) -> CalibrationMode:
+        """Return the current calibration mode."""
+        raw = int(self._query("USERCAL:SELECT?"))
+        return CalibrationMode.USER if raw else CalibrationMode.DEFAULT
+
+    def perform_user_calibration(self) -> None:
+        """Execute the user-intensity calibration (rescales to 1.00 sun)."""
+        self._write("USERCAL:PERFORM")
+
+    # ------------------------------------------------------------------
+    # Status and diagnostics
+    # ------------------------------------------------------------------
+
+    def get_status(self) -> LampStatus:
+        """Return a decoded :class:`LampStatus` from the ``STATUS?`` query.
+
+        Bit definitions (manual p. 30):
+        - bit 0: output on
+        - bit 2: head disconnected
+        - bit 3: head warming up
+        - bit 4: head over-temperature
+        """
+        raw = int(self._query("STATUS?"))
+        return LampStatus(
+            output_on=bool(raw & (1 << 0)),
+            head_disconnected=bool(raw & (1 << 2)),
+            head_warming_up=bool(raw & (1 << 3)),
+            head_overtemperature=bool(raw & (1 << 4)),
+            raw=raw,
+        )
+
+    def get_errors(self) -> list[str]:
+        """Drain and return all queued error strings from the instrument."""
+        errors: list[str] = []
+        while True:
+            response = self._query("ERROR?")
+            if response.startswith("0"):
+                break
+            errors.append(response)
+        return errors
+
+    # ------------------------------------------------------------------
+    # LED self-test
+    # ------------------------------------------------------------------
+
+    def run_led_test(self, timeout_s: float = 60.0) -> bool:
+        """Trigger the LED self-test sequence (``LEDTEST:POWER?``)."""
+        original_timeout = self._instr.timeout
+        self._instr.timeout = int(timeout_s * 1000)
+        try:
+            result = self._query("LEDTEST:POWER?")
+        finally:
+            self._instr.timeout = original_timeout
+        return result.strip() == "1"
+
+    def get_led_test_result(self, led: int) -> tuple[float, float]:
+        """Return ``(user_power, factory_power)`` in kW m⁻² for *led*."""
+        self._validate_led_index(led)
+        response = self._query(f"LEDTEST:RESULT? {led}")
+        parts = [p.strip() for p in response.split(",")]
+        return float(parts[0]), float(parts[1])
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+
+    def wait_for_warmup(self, poll_interval_s: float = 5.0, timeout_s: float = 900.0) -> None:
+        """Block until the LED head reaches operating temperature (~15 min)."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            status = self.get_status()
+            if status.head_disconnected:
+                raise RuntimeError("LED head is disconnected — check the CC720 cable.")
+            if not status.head_warming_up:
+                return
+            time.sleep(poll_interval_s)
+        raise TimeoutError(
+            f"LED head did not reach operating temperature within {timeout_s:.0f} s."
+        )
+
+    def set_spectrum_am15g(self) -> None:
+        """Convenience: recall the factory AM1.5G spectrum (location 0)."""
+        self.recall_spectrum(0)
+
+    def set_spectrum_custom(self) -> None:
+        """Convenience: recall the front-panel 'custom' spectrum (location 1)."""
+        self.recall_spectrum(1)
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience function
+# ---------------------------------------------------------------------------
+
+def list_instruments() -> list[str]:
+    """Return resource strings for all connected USB INSTR / USBTMC devices."""
+    rm = pyvisa.ResourceManager()
+    try:
+        resources: list[str] = list(rm.list_resources("USB?*INSTR"))
+    except Exception:
+        resources = []
+    finally:
+        rm.close()
+
+    # Windows fallback: find any VeraSol reachable via the IVI USBTMC driver
+    # that is not already listed as a VISA USB resource.
+    win_path = _find_win_usbtmc_device()
+    if win_path is not None and win_path not in resources:
+        resources.append(win_path)
+
+    return resources

--- a/src/iv_lab/hardware/lamp/drivers/verasol.py
+++ b/src/iv_lab/hardware/lamp/drivers/verasol.py
@@ -1,0 +1,131 @@
+"""VeraSol LSS-7120 LED solar simulator driver.
+
+Uses the low-level USBTMC library in ``_verasol_lib.py``.  Connection is USB
+(USBTMC); pyvisa and the Windows IVI USBTMC fallback are loaded inside
+``_open()`` only (never at package import time).
+
+The VeraSol accepts a continuous amplitude from 0.1 to 1.0 sun.  The lamp
+interface passes ``light_int`` as percent of one sun, so the conversion is::
+
+    amplitude [suns] = light_int [%] / 100
+
+``light_int == 0`` is the dark condition: the output is turned off but
+``light_is_on`` is still set ``True`` (consistent with legacy behavior for
+other lamp types).  Values between 0 and 10 % exclusive are rejected because
+the instrument's minimum amplitude is 0.1 sun (10 %).
+
+No ``lightLevelDict`` is required in the settings: the VeraSol takes any
+amplitude in its operating range directly from ``light_int``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from iv_lab.config import LampSettings
+from iv_lab.hardware.errors import HardwareCommandError, HardwareConnectionError
+from iv_lab.hardware.smu.base import BaseSMU
+
+from ..base import BaseLamp
+from ..registry import register_lamp_driver
+
+_VERASOL_IDN_HINT = "LSS-7120"
+_MIN_SUNS = 0.1   # instrument minimum amplitude
+
+
+@register_lamp_driver("VeraSol", "LSS-7120")
+class VeraSolLamp(BaseLamp):
+    """Oriel VeraSol LSS-7120 LED solar simulator (USB/USBTMC)."""
+
+    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+        super().__init__(settings, smu=smu)
+        # None / empty string both trigger auto-discovery in _verasol_lib.VeraSol
+        self._visa_address: Optional[str] = settings.visa_address or None
+        self._lamp = None
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    def _open(self) -> None:
+        try:
+            from ._verasol_lib import VeraSol
+        except ImportError as exc:
+            raise HardwareConnectionError(
+                "pyvisa is required for the VeraSol lamp: "
+                "pip install pyvisa pyvisa-py"
+            ) from exc
+
+        try:
+            self._lamp = VeraSol(self._visa_address)
+            idn = self._lamp.identify()
+        except ImportError as exc:
+            # pyvisa missing — raised at VeraSol() instantiation time in tests
+            raise HardwareConnectionError(
+                "pyvisa is required for the VeraSol lamp: "
+                "pip install pyvisa pyvisa-py"
+            ) from exc
+        except RuntimeError as exc:
+            raise HardwareConnectionError(str(exc)) from exc
+
+        if _VERASOL_IDN_HINT not in idn:
+            self._lamp.close()
+            self._lamp = None
+            raise HardwareConnectionError(
+                f"VeraSol IDN check failed: expected {_VERASOL_IDN_HINT!r} "
+                f"in response, got {idn!r}"
+            )
+
+    def _close(self) -> None:
+        if self._lamp is not None:
+            self._lamp.close()
+            self._lamp = None
+
+    # ------------------------------------------------------------------
+    # Light control
+    # ------------------------------------------------------------------
+
+    def light_on(self, light_int: float = 100.0) -> None:
+        self.light_is_on = False
+
+        if light_int == 0.0:
+            # Dark condition: ensure output is off; still mark as "configured".
+            if self._lamp is not None:
+                try:
+                    self._lamp.set_output(False)
+                except RuntimeError as exc:
+                    raise HardwareCommandError(str(exc)) from exc
+            self.light_int = light_int
+            self.light_is_on = True
+            return
+
+        suns = light_int / 100.0
+        if suns < _MIN_SUNS:
+            raise HardwareCommandError(
+                f"VeraSol minimum amplitude is {_MIN_SUNS} sun "
+                f"({_MIN_SUNS * 100:.0f} %). Requested {light_int:.2f} %."
+            )
+
+        try:
+            self._lamp.set_amplitude(suns)
+            self._lamp.set_output(True)
+        except RuntimeError as exc:
+            raise HardwareCommandError(str(exc)) from exc
+
+        actual = self._lamp.get_amplitude()
+        if abs(actual - suns) > 0.005:
+            raise HardwareCommandError(
+                f"VeraSol amplitude mismatch: requested {suns:.3f} sun, "
+                f"instrument reports {actual:.3f} sun."
+            )
+
+        self.light_int = light_int
+        self.light_is_on = True
+
+    def light_off(self) -> None:
+        if self._lamp is not None:
+            try:
+                self._lamp.set_output(False)
+            except RuntimeError as exc:
+                raise HardwareCommandError(str(exc)) from exc
+        self.light_is_on = False

--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -39,6 +39,20 @@ from iv_lab.hardware.errors import HardwareCommandError
 from ..base import BaseSMU, SMUChannel
 from ..registry import register_smu_driver
 
+# Default RS-232 parameters for a serial Keithley 2400.  These must match the
+# instrument's front-panel RS-232 settings; override per-machine via the
+# ``baud_rate`` / ``read_termination`` / ``write_termination`` settings keys.
+# Over GPIB/USB the bus signals end-of-message (EOI), so no termination
+# character is needed and these defaults are not applied.
+_SERIAL_DEFAULTS = {
+    "baud_rate": 9600,
+    "read_termination": "\n",   # Keithley COMM menu TERMINATOR <LF> (SCPI default)
+    "write_termination": "\n",
+}
+#: Default VISA read timeout (ms).  Serial reads are slower than GPIB; a too
+#: short timeout turns a slow-but-valid read into a spurious VI_ERROR_TMO.
+_DEFAULT_TIMEOUT_MS = 5000.0
+
 
 @dataclass
 class _ChannelState:
@@ -91,19 +105,40 @@ class Keithley2400FamilySMU(BaseSMU):
 
     # --- connection (legacy connect/disconnect, 2400-family branch) ---
 
+    def _connection_kwargs(self) -> dict:
+        """Build the pyvisa connection kwargs for the pymeasure adapter.
+
+        For serial (``ASRL``) addresses, RS-232 needs explicit baud rate and
+        termination characters or every read hangs until the VISA timeout
+        (GPIB/USB signal end-of-message on the bus, so they need none). The
+        defaults come from ``_SERIAL_DEFAULTS`` and can be overridden per
+        machine via the settings file. A read ``timeout`` is always applied.
+        """
+        kwargs: dict = {}
+        timeout = self.settings.timeout_ms
+        kwargs["timeout"] = _DEFAULT_TIMEOUT_MS if timeout is None else timeout
+
+        if str(self.visa_address)[:4].upper() == "ASRL":
+            for key, default in _SERIAL_DEFAULTS.items():
+                override = getattr(self.settings, key, None)
+                kwargs[key] = default if override is None else override
+        return kwargs
+
     def _open(self) -> None:
+        kwargs = self._connection_kwargs()
+
         # deferred import: must not be loaded at package import time
         if self.model == "2450":
             from pymeasure.instruments.keithley import Keithley2450
 
-            self.smu = Keithley2450(self.visa_address)
+            self.smu = Keithley2450(self.visa_address, **kwargs)
         else:
             from pymeasure.instruments.keithley import Keithley2400
 
-            self.smu = Keithley2400(self.visa_address)
+            self.smu = Keithley2400(self.visa_address, **kwargs)
 
         self.smu.reset()
-        self.smu.use_front_terminals()
+        self.smu.front_terminals_enabled = True
         self._current_channel = SMUChannel.CELL
 
         self.smu.wires = 4 if self.sense_mode_a == "4 wire" else 2
@@ -163,10 +198,10 @@ class Keithley2400FamilySMU(BaseSMU):
 
         # front terminals are the cell, rear terminals the reference diode
         if channel == SMUChannel.CELL:
-            self.smu.use_front_terminals()
+            self.smu.front_terminals_enabled = True
             sense_mode = self.sense_mode_a
         else:
-            self.smu.use_rear_terminals()
+            self.smu.front_terminals_enabled = False
             sense_mode = self.sense_mode_b
         self.smu.wires = 4 if sense_mode == "4 wire" else 2
 

--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -290,8 +290,11 @@ class Keithley2400FamilySMU(BaseSMU):
             self.smu.disable_source()
         self.smu.source_mode = "current"
         # legacy passed its whole range/autorange dicts here, which are
-        # always truthy: the effective call is nplc=1 with autoranging on
-        self.smu.measure_voltage(1, state.v_range, True)
+        # always truthy: the effective call is nplc=1 with autoranging on.
+        # pymeasure 0.16 deprecated the measure_voltage(nplc, range, auto)
+        # config form; configure the equivalent explicitly instead.
+        self.smu.voltage_nplc = 1
+        self.smu.voltage_range_auto_enabled = True
         if state.output:
             self.smu.enable_source()
         state.source_mode = "current"
@@ -305,8 +308,11 @@ class Keithley2400FamilySMU(BaseSMU):
         if state.output:
             self.smu.disable_source()
         self.smu.source_mode = "voltage"
-        # see set_mode_current_source: effectively nplc=1, autorange on
-        self.smu.measure_current(1, state.i_range, True)
+        # see set_mode_current_source: effectively nplc=1, autorange on.
+        # pymeasure 0.16 deprecated the measure_current(nplc, range, auto)
+        # config form; configure the equivalent explicitly instead.
+        self.smu.current_nplc = 1
+        self.smu.current_range_auto_enabled = True
         if state.output:
             self.smu.enable_source()
         state.source_mode = "voltage"

--- a/tests/test_lamp_real_drivers.py
+++ b/tests/test_lamp_real_drivers.py
@@ -1,5 +1,5 @@
 """Tests for the real lamp drivers (Wavelabs, Oriel, Trinamic, Keithley
-filter wheel).
+filter wheel, VeraSol).
 
 No hardware library is required: pyvisa and pytrinamic are faked via
 ``sys.modules`` injection, the Wavelabs socket is faked by patching the
@@ -22,6 +22,7 @@ from iv_lab.hardware.lamp import create_lamp, get_lamp_driver
 from iv_lab.hardware.lamp.drivers.keithley_filter import KeithleyFilterWheelLamp
 from iv_lab.hardware.lamp.drivers.oriel import OrielLSS7120Lamp
 from iv_lab.hardware.lamp.drivers.trinamic import TrinamicFilterWheelLamp
+from iv_lab.hardware.lamp.drivers.verasol import VeraSolLamp
 from iv_lab.hardware.lamp.drivers.wavelabs import WavelabsLamp
 from iv_lab.hardware.smu.base import SMUChannel
 from iv_lab.hardware.smu.drivers.emulated import EmulatedSMU
@@ -41,6 +42,7 @@ def lamp_settings(brand, model, light_levels, **overrides) -> LampSettings:
 def test_real_drivers_are_registered() -> None:
     assert get_lamp_driver("Wavelabs", "Sinus70") is WavelabsLamp
     assert get_lamp_driver("Oriel", "LSS-7120") is OrielLSS7120Lamp
+    assert get_lamp_driver("VeraSol", "LSS-7120") is VeraSolLamp
     assert get_lamp_driver("keithley", "filter wheel") is KeithleyFilterWheelLamp
     for model in ("TMCM-1260", "TMCM-1160", "TMCM-3110"):
         assert get_lamp_driver("Trinamic", model) is TrinamicFilterWheelLamp
@@ -582,3 +584,310 @@ def test_factory_passes_smu_to_keithley_filter() -> None:
     assert lamp.smu is smu
     # sanity: the dummy SMU still behaves like a BaseSMU
     assert smu.measure_current(SMUChannel.CELL) is not None
+
+
+# --- VeraSol LSS-7120 ---
+
+
+class FakeVeraSol:
+    """Stand-in for _verasol_lib.VeraSol used in tests."""
+
+    def __init__(self, resource_name=None, timeout_ms=10_000) -> None:
+        self.resource_name = resource_name
+        self._amplitude: float = 1.0
+        self._output: bool = False
+        self.idn_str: str = "Newport Corporation,LSS-7120,sn123,rev1"
+        self.closed: bool = False
+
+    def identify(self) -> str:
+        return self.idn_str
+
+    def set_amplitude(self, suns: float) -> None:
+        self._amplitude = suns
+
+    def get_amplitude(self) -> float:
+        return self._amplitude
+
+    def set_output(self, on: bool) -> None:
+        self._output = on
+
+    def get_output(self) -> bool:
+        return self._output
+
+    def set_spectrum_am15g(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_verasol_lib(monkeypatch):
+    instance = FakeVeraSol()
+
+    def _make(resource_name=None, timeout_ms=10_000):
+        instance.resource_name = resource_name
+        return instance
+
+    module = types.ModuleType("iv_lab.hardware.lamp.drivers._verasol_lib")
+    module.VeraSol = _make
+    monkeypatch.setitem(
+        sys.modules, "iv_lab.hardware.lamp.drivers._verasol_lib", module
+    )
+    return instance
+
+
+def make_verasol(**overrides) -> VeraSolLamp:
+    data = {"brand": "VeraSol", "model": "LSS-7120", "emulate": False}
+    data.update(overrides)
+    settings = LampSettings(**data)
+    return VeraSolLamp(settings)
+
+
+def test_verasol_connect_checks_idn(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+
+    assert lamp.is_connected()
+
+
+def test_verasol_bad_idn_raises(fake_verasol_lib) -> None:
+    fake_verasol_lib.idn_str = "Some Other Device,XYZ,000"
+    lamp = make_verasol()
+
+    with pytest.raises(HardwareConnectionError, match="IDN check failed"):
+        lamp.connect()
+
+    assert not lamp.is_connected()
+
+
+def test_verasol_connect_missing_pyvisa_raises(monkeypatch) -> None:
+    module = types.ModuleType("iv_lab.hardware.lamp.drivers._verasol_lib")
+
+    def _raise(*args, **kwargs):
+        raise ImportError("No module named 'pyvisa'")
+
+    module.VeraSol = _raise
+    monkeypatch.setitem(
+        sys.modules, "iv_lab.hardware.lamp.drivers._verasol_lib", module
+    )
+    lamp = make_verasol()
+
+    with pytest.raises(HardwareConnectionError, match="pyvisa"):
+        lamp.connect()
+
+
+def test_verasol_light_on_sets_amplitude_and_output(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+
+    lamp.light_on(100.0)
+
+    assert lamp.light_is_on
+    assert lamp.light_int == 100.0
+    assert fake_verasol_lib._amplitude == pytest.approx(1.0)
+    assert fake_verasol_lib._output is True
+
+
+def test_verasol_light_on_50_percent(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+
+    lamp.light_on(50.0)
+
+    assert lamp.light_is_on
+    assert fake_verasol_lib._amplitude == pytest.approx(0.5)
+    assert fake_verasol_lib._output is True
+
+
+def test_verasol_light_on_zero_turns_output_off(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+    fake_verasol_lib._output = True   # simulate output was on
+
+    lamp.light_on(0.0)
+
+    assert lamp.light_is_on          # legacy: still counts as "on"
+    assert lamp.light_int == 0.0
+    assert fake_verasol_lib._output is False
+
+
+def test_verasol_light_on_below_minimum_raises(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+
+    with pytest.raises(HardwareCommandError, match="minimum amplitude"):
+        lamp.light_on(5.0)
+
+    assert not lamp.light_is_on
+
+
+def test_verasol_amplitude_mismatch_raises(fake_verasol_lib) -> None:
+    # Fake an instrument that reports a different amplitude than requested.
+    fake_verasol_lib._amplitude = 0.5  # will be reported after set_amplitude
+    original_set = FakeVeraSol.set_amplitude
+
+    def _bad_set(self, suns):
+        pass  # don't update _amplitude — simulate mismatch
+
+    fake_verasol_lib.set_amplitude = _bad_set.__get__(fake_verasol_lib, FakeVeraSol)
+
+    lamp = make_verasol()
+    lamp.connect()
+
+    with pytest.raises(HardwareCommandError, match="amplitude mismatch"):
+        lamp.light_on(100.0)
+
+    assert not lamp.light_is_on
+
+
+def test_verasol_light_off_turns_output_off(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+    lamp.light_on(100.0)
+
+    lamp.light_off()
+
+    assert not lamp.light_is_on
+    assert fake_verasol_lib._output is False
+
+
+def test_verasol_light_off_safe_when_already_off(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+
+    lamp.light_off()   # must not raise
+
+    assert not lamp.light_is_on
+
+
+def test_verasol_disconnect_closes_lib(fake_verasol_lib) -> None:
+    lamp = make_verasol()
+    lamp.connect()
+    lamp.disconnect()
+
+    assert fake_verasol_lib.closed
+    assert not lamp.is_connected()
+
+
+def test_verasol_settings_without_light_level_dict() -> None:
+    # VeraSol does not require lightLevelDict in its settings.
+    settings = LampSettings(brand="VeraSol", model="LSS-7120", emulate=False)
+
+    assert settings.lightLevelDict is None
+
+
+def test_verasol_auto_discover_passes_none_resource(fake_verasol_lib) -> None:
+    # When visa_address is omitted from settings, the driver passes None
+    # to _verasol_lib.VeraSol so it auto-discovers the instrument.
+    lamp = make_verasol()   # no visa_address keyword
+    lamp.connect()
+
+    assert fake_verasol_lib.resource_name is None
+
+
+def test_verasol_explicit_visa_address_is_forwarded(fake_verasol_lib) -> None:
+    lamp = make_verasol(visa_address="USB0::0x1028::0x0001::71201234::INSTR")
+    lamp.connect()
+
+    assert fake_verasol_lib.resource_name == "USB0::0x1028::0x0001::71201234::INSTR"
+
+
+# --- _write() protocol tests (NI-VISA vs _WinUSBTMC acknowledgement encoding) ---
+#
+# The VeraSol acknowledges write commands with a 0-byte USB END (EOM) message.
+# _WinUSBTMC translates this to the string "Ready"; NI-VISA returns "".
+# Both must be accepted.  A non-empty unexpected string must raise RuntimeError.
+#
+# These tests load _verasol_lib with a *fake* pyvisa so the real pyvisa library
+# never enters sys.modules (which would break test_smu_emulation isolation checks).
+
+
+@pytest.fixture
+def verasol_cls(monkeypatch):
+    """Provide the VeraSol class loaded against a fake pyvisa.
+
+    Uses monkeypatch to inject a fake pyvisa module before importing
+    _verasol_lib, then cleans up _verasol_lib from sys.modules at teardown.
+    Real pyvisa is never loaded, preserving sys.modules isolation for other tests.
+    """
+    import importlib
+
+    fake_pyvisa = types.ModuleType("pyvisa")
+    fake_pyvisa.errors = types.SimpleNamespace(VisaIOError=OSError)
+    # monkeypatch records "pyvisa was absent" and will delete it at teardown
+    monkeypatch.setitem(sys.modules, "pyvisa", fake_pyvisa)
+
+    _key = "iv_lab.hardware.lamp.drivers._verasol_lib"
+    sys.modules.pop(_key, None)           # remove any cached copy with real pyvisa
+    lib = importlib.import_module(_key)   # fresh import against fake pyvisa
+
+    yield lib.VeraSol
+
+    sys.modules.pop(_key, None)           # remove so no live reference to fake pyvisa
+
+
+class _FakeInstr:
+    """Minimal pyvisa-resource stand-in: records writes and returns a preset ack."""
+
+    def __init__(self, ack: str) -> None:
+        self._ack = ack
+        self.written: list[str] = []
+        self.read_termination = "\n"   # default; __init__ should change this to ""
+        self.write_termination = "\n"
+        self.timeout = 10_000
+
+    def write(self, cmd: str) -> None:
+        self.written.append(cmd)
+
+    def read(self) -> str:
+        return self._ack
+
+    def close(self) -> None:
+        pass
+
+
+def _make_write_obj(VeraSol, ack: str):
+    """Create a VeraSol instance via object.__new__ with a preset fake _instr.
+
+    Bypasses __init__ so no VISA connection is attempted.
+    """
+    obj = object.__new__(VeraSol)
+    obj._instr = _FakeInstr(ack)
+    return obj, obj._instr
+
+
+def test_write_accepts_empty_ack_ni_visa(verasol_cls) -> None:
+    # NI-VISA returns "" for the 0-byte EOM acknowledgement — must not raise.
+    lamp, _ = _make_write_obj(verasol_cls, ack="")
+    lamp._write("AMPLITUDE 1.000")
+
+
+def test_write_accepts_ready_ack_winusbtmc(verasol_cls) -> None:
+    # _WinUSBTMC returns "Ready" for the 0-byte EOM acknowledgement — must not raise.
+    lamp, _ = _make_write_obj(verasol_cls, ack="Ready")
+    lamp._write("OUTPUT ON")
+
+
+def test_write_rejects_unexpected_ack(verasol_cls) -> None:
+    # Any non-empty string that is not "ready" signals an instrument fault.
+    lamp, _ = _make_write_obj(verasol_cls, ack="ERROR: invalid command")
+
+    with pytest.raises(RuntimeError, match="Unexpected acknowledgement"):
+        lamp._write("AMPLITUDE 1.000")
+
+
+def test_read_termination_is_empty_on_ni_visa_path(verasol_cls, monkeypatch) -> None:
+    # Verify that VeraSol.__init__ sets read_termination="" on the pyvisa resource,
+    # so NI-VISA terminates reads on the USB END bit rather than waiting for "\n".
+    fake_res = _FakeInstr(ack="")   # read_termination starts as "\n"
+    fake_rm = types.SimpleNamespace(
+        list_resources=lambda _: ["USB0::fake::INSTR"],
+        open_resource=lambda _: fake_res,
+        close=lambda: None,
+    )
+    sys.modules["pyvisa"].ResourceManager = lambda: fake_rm
+
+    lamp = verasol_cls(resource_name="USB0::fake::INSTR")
+
+    assert lamp._instr.read_termination == ""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -148,6 +148,31 @@ def test_non_manual_lamp_requires_light_level_dict(tmp_path: Path) -> None:
     assert "lightLevelDict" in str(excinfo.value)
 
 
+def test_verasol_lamp_does_not_require_light_level_dict(tmp_path: Path) -> None:
+    data = json.loads(json.dumps(MINIMAL_SETTINGS))
+    data["lamp"] = {
+        "brand": "VeraSol",
+        "model": "LSS-7120",
+        "emulate": False,
+        "display name": "Oriel VeraSol LSS-7120",
+    }
+
+    settings = load_settings(write_settings(tmp_path, data))
+
+    assert settings.lamp.brand == "VeraSol"
+    assert settings.lamp.lightLevelDict is None
+
+
+def test_verasol_lamp_visa_address_optional(tmp_path: Path) -> None:
+    # visa_address omitted — driver auto-discovers the instrument.
+    data = json.loads(json.dumps(MINIMAL_SETTINGS))
+    data["lamp"] = {"brand": "VeraSol", "model": "LSS-7120", "emulate": False}
+
+    settings = load_settings(write_settings(tmp_path, data))
+
+    assert settings.lamp.visa_address is None
+
+
 def test_arduino_section_is_parsed_when_present(tmp_path: Path) -> None:
     data = json.loads(json.dumps(MINIMAL_SETTINGS))
     data["arduino"] = {
@@ -281,6 +306,7 @@ def test_toml_unsupported_extension_raises(tmp_path: Path) -> None:
         "dell.toml",
         "fte.toml",
         "old_iv.toml",
+        "verasol_glovebox.toml",
     ],
 )
 def test_committed_toml_examples_load(example: str) -> None:

--- a/tests/test_smu_keithley_2400.py
+++ b/tests/test_smu_keithley_2400.py
@@ -44,9 +44,10 @@ class FakeKeithley:
     instances: list = []
     fail_on_init = False
 
-    def __init__(self, visa_address: str) -> None:
+    def __init__(self, visa_address: str, **kwargs) -> None:
         object.__setattr__(self, "log", [])
         object.__setattr__(self, "visa_address", visa_address)
+        object.__setattr__(self, "init_kwargs", dict(kwargs))
         object.__setattr__(self, "adapter", FakeAdapter())
         object.__setattr__(self, "voltage_reading", 0.42)
         object.__setattr__(self, "current_reading", -0.0033)
@@ -179,7 +180,7 @@ def test_connect_imports_pymeasure_and_configures_instrument(fake_pymeasure) -> 
 
     # legacy connect sequence
     assert fake.calls("reset")
-    assert fake.calls("use_front_terminals")
+    assert True in fake.sets("front_terminals_enabled")
     assert fake.sets("wires") == [2]
     assert fake.sets("voltage_nplc") == [1]
     assert fake.sets("current_nplc") == [1]
@@ -209,6 +210,52 @@ def test_serial_interface_measurement_period(fake_pymeasure) -> None:
     smu.connect()
 
     assert smu.meas_period_min == pytest.approx(1 / 6)
+
+
+def test_serial_address_passes_rs232_connection_kwargs(fake_pymeasure) -> None:
+    # ASRL (serial) addresses need baud rate + termination or reads hang;
+    # the driver supplies RS-232 defaults plus a read timeout.
+    smu = Keithley2400FamilySMU(make_settings(visa_address="ASRL4::INSTR"))
+    smu.connect()
+
+    kwargs = fake_pymeasure.Keithley2400.instances[0].init_kwargs
+    assert kwargs["baud_rate"] == 9600
+    assert kwargs["read_termination"] == "\n"
+    assert kwargs["write_termination"] == "\n"
+    assert kwargs["timeout"] == 5000.0
+
+
+def test_serial_kwargs_overridden_from_settings(fake_pymeasure) -> None:
+    # Per-machine settings override the RS-232 defaults.
+    smu = Keithley2400FamilySMU(
+        make_settings(
+            visa_address="ASRL4::INSTR",
+            baud_rate=19200,
+            read_termination="\n",
+            write_termination="\n",
+            timeout_ms=8000,
+        )
+    )
+    smu.connect()
+
+    kwargs = fake_pymeasure.Keithley2400.instances[0].init_kwargs
+    assert kwargs["baud_rate"] == 19200
+    assert kwargs["read_termination"] == "\n"
+    assert kwargs["write_termination"] == "\n"
+    assert kwargs["timeout"] == 8000
+
+
+def test_gpib_address_gets_no_serial_kwargs(fake_pymeasure) -> None:
+    # Over GPIB the bus signals end-of-message; no termination/baud is sent,
+    # only the read timeout.
+    smu = Keithley2400FamilySMU(make_settings(visa_address="GPIB0::24::INSTR"))
+    smu.connect()
+
+    kwargs = fake_pymeasure.Keithley2400.instances[0].init_kwargs
+    assert "baud_rate" not in kwargs
+    assert "read_termination" not in kwargs
+    assert "write_termination" not in kwargs
+    assert kwargs["timeout"] == 5000.0
 
 
 def test_fast_meas_speed_sets_nplc(fake_pymeasure) -> None:
@@ -348,7 +395,7 @@ def test_reference_channel_switches_to_rear_terminals(fake_pymeasure) -> None:
 
     # output disabled first, then rear terminals selected
     assert fake.log[0] == ("call", "disable_source")
-    assert fake.calls("use_rear_terminals")
+    assert False in fake.sets("front_terminals_enabled")
     # reference diode sense mode (settings default "2wire" -> 2)
     assert 2 in fake.sets("wires")
 
@@ -359,8 +406,8 @@ def test_same_channel_operations_do_not_toggle(fake_pymeasure) -> None:
     smu.set_voltage(SMUChannel.CELL, 0.1)
     smu.set_voltage(SMUChannel.CELL, 0.2)
 
-    assert not fake.calls("use_rear_terminals")
-    assert not fake.calls("use_front_terminals")
+    assert False not in fake.sets("front_terminals_enabled")
+    assert True not in fake.sets("front_terminals_enabled")
 
 
 def test_switching_back_restores_cell_channel_state(fake_pymeasure) -> None:
@@ -372,7 +419,7 @@ def test_switching_back_restores_cell_channel_state(fake_pymeasure) -> None:
 
     smu.set_voltage(SMUChannel.CELL, 0.6)  # triggers toggle back to front
 
-    assert fake.calls("use_front_terminals")
+    assert True in fake.sets("front_terminals_enabled")
     # the cached cell set-voltage is replayed during the toggle
     assert 0.6 in fake.sets("source_voltage")
 

--- a/tests/test_smu_keithley_2400.py
+++ b/tests/test_smu_keithley_2400.py
@@ -299,9 +299,11 @@ def test_setup_voltage_output_replicates_legacy_sequence(fake_pymeasure) -> None
     assert fake.sets("compliance_current") == [0.02]
     # autorange on (settings default autorange=True)
     assert ":CURR:RANG:AUTO ON" in fake.writes()
-    # voltage source mode with measure_current configured (nplc=1, autorange)
+    # voltage source mode with current measurement configured (nplc=1, autorange);
+    # pymeasure 0.16 replaced measure_current(nplc, range, auto) with explicit props
     assert fake.sets("source_mode") == ["voltage"]
-    assert fake.calls("measure_current")[0][2] == 1
+    assert 1 in fake.sets("current_nplc")
+    assert fake.sets("current_range_auto_enabled") == [True]
     # current display (legacy SYST:KEY 22, non-2450 only)
     assert "SYST:KEY 22" in fake.writes()
 


### PR DESCRIPTION
## Summary

Adds the Oriel VeraSol LSS-7120 LED solar simulator as a first-class lamp driver and wires up a new glovebox station: **VeraSol over USB + Keithley 2400 over RS-232 (COM4)**.

## Lamp

- New `VeraSolLamp` driver (`hardware/lamp/drivers/verasol.py`) backed by a bundled USBTMC library (`_verasol_lib.py`, copied from `docs/verasol`).
- `light_int` (% sun) maps directly to amplitude in suns; `light_int == 0` is the dark condition (output off). No `lightLevelDict` required.
- `_write()` accepts both acknowledgement encodings: `''` (NI-VISA 0-byte EOM) and `'Ready'` (Windows IVI USBTMC), and sets `read_termination=''` so reads terminate on the USB END bit instead of timing out waiting for a newline.
- Settings validator exempts the `verasol` brand from requiring a `lightLevelDict`.

## SMU (serial Keithley 2400)

- The Keithley driver now passes RS-232 parameters (`baud_rate`, read/write termination) plus a read timeout for `ASRL` addresses; GPIB/USB get only the timeout (EOI handles end-of-message). Without this, serial reads hang until `VI_ERROR_TMO`. Defaults: 9600 baud, `<LF>` terminators, 5000 ms.
- `SMUSettings` gains optional `baud_rate` / `read_termination` / `write_termination` / `timeout_ms` fields so each machine can match its instrument's COMM menu.
- Replaced deprecated `use_front_terminals()` / `use_rear_terminals()` with the `front_terminals_enabled` property, and the deprecated `measure_current/measure_voltage(nplc, range, auto)` config form with the explicit `*_nplc` / `*_range_auto_enabled` properties (pymeasure 0.16).

## Config

- `config/examples/verasol_glovebox.toml`: committed template for the glovebox station with documented serial settings and a 100/50/20/10/Dark light-level table.

## Tests

- VeraSol driver, `_write()` ack-encoding protocol, settings validation, and Keithley serial/GPIB connection-kwargs coverage.
- Full suite: **399 passing**.

## Verified on hardware

J-V scan, Constant-Voltage (measure J), and MPP run on the glovebox station (VeraSol lamp + serial Keithley 2400) after matching the instrument's `TERMINATOR: <LF>` setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)