### PR TITLE
chore: ruff, UTF-8 file I/O, and optional hardware deps

### DIFF
--- a/docs/verasol/test_connection.py
+++ b/docs/verasol/test_connection.py
@@ -9,7 +9,7 @@ as a USB INSTR resource.
 import ctypes
 import struct
 import time
-from ctypes import windll, create_string_buffer, c_ulong, byref
+from ctypes import byref, c_ulong, create_string_buffer, windll
 
 DEVICE_PATH = (
     r"\\?\USB#VID_1FDE&PID_000A&MI_00"

--- a/docs/verasol/verasol.py
+++ b/docs/verasol/verasol.py
@@ -28,7 +28,6 @@ import sys
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 try:
     import pyvisa
@@ -41,7 +40,8 @@ except ImportError as exc:  # pragma: no cover
 if sys.platform == "win32":
     import ctypes
     import winreg
-    from ctypes import windll, create_string_buffer, c_ulong, byref as _byref
+    from ctypes import byref as _byref
+    from ctypes import c_ulong, create_string_buffer, windll
     _WIN32_AVAILABLE = True
 else:
     _WIN32_AVAILABLE = False
@@ -188,7 +188,7 @@ class _WinUSBTMC:
         return self.read()
 
 
-def _find_win_usbtmc_device(idn_hint: str = _VERASOL_IDN_HINT) -> Optional[str]:
+def _find_win_usbtmc_device(idn_hint: str = _VERASOL_IDN_HINT) -> str | None:
     """
     Search the Windows device-interface registry for a USBTMC instrument whose
     ``*IDN?`` response contains *idn_hint*.  Returns the Win32 device path on
@@ -253,7 +253,7 @@ class VeraSol:
 
     def __init__(
         self,
-        resource_name: Optional[str] = None,
+        resource_name: str | None = None,
         timeout_ms: int = 10_000,
     ) -> None:
         self._rm = None
@@ -296,7 +296,7 @@ class VeraSol:
     # Context manager
     # ------------------------------------------------------------------
 
-    def __enter__(self) -> "VeraSol":
+    def __enter__(self) -> VeraSol:
         return self
 
     def __exit__(self, *_) -> None:

--- a/docs/verasol/verasol_gui.py
+++ b/docs/verasol/verasol_gui.py
@@ -11,34 +11,50 @@ Place verasol.py in the same directory, then run:
 from __future__ import annotations
 
 import sys
-import traceback
-from typing import Optional
 
 from PySide6.QtCore import (
-    Qt, QThread, Signal, QTimer, QObject, Slot,
+    QObject,
+    Qt,
+    QThread,
+    QTimer,
+    Signal,
+    Slot,
 )
-from PySide6.QtGui import QColor, QFont, QPalette, QIcon, QPainter
+from PySide6.QtGui import QColor, QFont, QPainter
 from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
-    QGridLayout, QGroupBox, QLabel, QPushButton, QSlider, QDoubleSpinBox,
-    QComboBox, QSpinBox, QTextEdit, QTabWidget, QSplitter, QFrame,
-    QProgressBar, QTableWidget, QTableWidgetItem, QHeaderView,
-    QMessageBox, QStatusBar, QCheckBox, QSizePolicy,
+    QApplication,
+    QComboBox,
+    QDoubleSpinBox,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMainWindow,
+    QProgressBar,
+    QPushButton,
+    QSlider,
+    QStatusBar,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
 )
 
 # ---------------------------------------------------------------------------
 # Try to import the verasol driver; fall back to a stub for UI development
 # ---------------------------------------------------------------------------
 try:
-    from verasol import VeraSol, CalibrationMode, LampStatus, LEDInfo, list_instruments
+    from verasol import CalibrationMode, LampStatus, LEDInfo, VeraSol, list_instruments
     DRIVER_AVAILABLE = True
 except Exception as _import_err:  # noqa: BLE001
     DRIVER_AVAILABLE = False
     _IMPORT_ERROR = str(_import_err)
 
     # ---- Minimal stubs so the GUI can be laid out without hardware ----
-    from enum import Enum
     from dataclasses import dataclass
+    from enum import Enum
 
     class CalibrationMode(str, Enum):
         DEFAULT = "DEFAULT"
@@ -143,7 +159,7 @@ class InstrumentWorker(QObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self._lamp: Optional[VeraSol] = None
+        self._lamp: VeraSol | None = None
 
     # ---- connection ----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,26 +12,37 @@ license = { text = "GPL-3.0-only" }
 authors = [
     { name = "EPFL LPI" },
 ]
-# Runtime dependencies are added as components are migrated (see docs/MIGRATION.md).
+# Core runtime dependencies. Lower bounds are conservative floors (well below
+# current releases) for reproducibility, not the versions developed against.
 dependencies = [
     "pydantic>=2",
-    "numpy",
-    "pandas",
+    "numpy>=1.24",
+    "pandas>=2.0",
     # JV metrics (Voc, Jsc, FF, PCE); imported lazily in analysis/jv_metrics.py
-    "scipy",
-    # Qt measurement workers and (later) the GUI; QtCore only in workers
-    "PySide6",
+    "scipy>=1.10",
+    # Qt measurement workers and the GUI; QtCore only in workers
+    "PySide6>=6.5",
     # J-V PDF reports; imported lazily in data/pdf_report.py
-    "matplotlib",
+    "matplotlib>=3.7",
     # GUI plotting (legacy used pyqtgraph as well)
-    "pyqtgraph",
+    "pyqtgraph>=0.13",
     # TOML round-trip writer (preserves comments when saving calibration to .toml)
-    "tomlkit",
+    "tomlkit>=0.12",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "ruff",
+]
+# Instrument-control libraries. These are imported lazily inside driver
+# connect() methods, so the app installs and runs in emulation without them.
+# Install the ones your rig needs, e.g. `pip install iv_lab[hardware]`.
+hardware = [
+    "pyvisa>=1.13",
+    "pyvisa-py>=0.7",   # pure-Python VISA backend (no NI-VISA required)
+    "pymeasure>=0.16",  # Keithley 2400/2450 drivers (non-deprecated API)
+    "pytrinamic",       # Trinamic filter-wheel controllers
 ]
 
 [tool.setuptools.packages.find]
@@ -40,3 +51,29 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+# Bundled, verbatim copies of legacy instrument libraries are kept as-is for
+# provenance (see CLAUDE.md); they are not maintained to this project's style.
+extend-exclude = [
+    "src/iv_lab/hardware/smu/drivers/_keithley26xx_lib.py",
+    "src/iv_lab/hardware/lamp/drivers/_verasol_lib.py",
+    "src/iv_lab/analysis/jv_analysis.py",
+    "IVLab",
+    "docs",
+]
+
+[tool.ruff.lint]
+# E/W pycodestyle, F pyflakes, I import sorting, UP pyupgrade,
+# B bugbear, C4 comprehensions, SIM simplify.
+select = ["E", "W", "F", "I", "UP", "B", "C4", "SIM"]
+# E501 (line length) is enforced by the formatter, not the linter, to avoid
+# churn on long legacy-derived comments and docstrings.
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test fixtures use dict(...) kwargs for readability (C408), and tests use
+# broad constructs by design.
+"tests/**" = ["C408"]

--- a/src/iv_lab/analysis/jv_metrics.py
+++ b/src/iv_lab/analysis/jv_metrics.py
@@ -11,8 +11,8 @@ consistent with the deferred-import policy for heavy scientific dependencies.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 
 @dataclass
@@ -41,6 +41,7 @@ def compute_jv_metrics(
     """
     import numpy as np
     import pandas as pd
+
     from . import jv_analysis
 
     j_density = np.array(current) / active_area  # A/cm²

--- a/src/iv_lab/config/settings.py
+++ b/src/iv_lab/config/settings.py
@@ -17,10 +17,9 @@ Defaults for optional fields replicate the legacy defaults set in
 from __future__ import annotations
 
 import json
-import tomllib
 from pathlib import Path
-from typing import Optional, Union
 
+import tomllib
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 #: Default settings filename.  The loader accepts .json and .toml.
@@ -71,13 +70,13 @@ class LampSettings(LegacyCompatibleModel):
     brand: str
     model: str
     emulate: bool
-    display_name: Optional[str] = Field(default=None, alias="display name")
-    lightLevelDict: Optional[dict[float, Union[int, float, str]]] = None
-    visa_address: Optional[str] = None
-    visa_library: Optional[str] = None
+    display_name: str | None = Field(default=None, alias="display name")
+    lightLevelDict: dict[float, int | float | str] | None = None
+    visa_address: str | None = None
+    visa_library: str | None = None
 
     @model_validator(mode="after")
-    def _apply_legacy_rules(self) -> "LampSettings":
+    def _apply_legacy_rules(self) -> LampSettings:
         # Legacy syst_param.__init__ fills in 'display name' if absent.
         if self.display_name is None:
             self.display_name = f"{self.brand} {self.model}"
@@ -110,11 +109,11 @@ class SMUSettings(LegacyCompatibleModel):
     #: Keithley these must match the instrument's front-panel RS-232 settings,
     #: or every read hangs until the VISA timeout.  ``None`` means "use the
     #: driver default" (see ``keithley_2400.py``).
-    baud_rate: Optional[int] = None
-    read_termination: Optional[str] = None
-    write_termination: Optional[str] = None
+    baud_rate: int | None = None
+    read_termination: str | None = None
+    write_termination: str | None = None
     #: VISA read timeout in milliseconds (applies to all interface types).
-    timeout_ms: Optional[float] = None
+    timeout_ms: float | None = None
 
 
 class ArduinoSettings(LegacyCompatibleModel):
@@ -123,7 +122,7 @@ class ArduinoSettings(LegacyCompatibleModel):
     brand: str
     model: str
     visa_address: str
-    visa_library: Optional[str] = None
+    visa_library: str | None = None
     emulate: bool = False
 
 
@@ -134,7 +133,7 @@ class SystemSettings(LegacyCompatibleModel):
     IVsys: IVSystemSettings
     lamp: LampSettings
     SMU: SMUSettings
-    arduino: Optional[ArduinoSettings] = None
+    arduino: ArduinoSettings | None = None
 
 
 def _update_toml_scalars(toml_node, data: dict) -> None:
@@ -154,7 +153,7 @@ def _update_toml_scalars(toml_node, data: dict) -> None:
             toml_node[key] = value
 
 
-def load_settings(path: Union[str, Path]) -> SystemSettings:
+def load_settings(path: str | Path) -> SystemSettings:
     """Load and validate a system settings file (.json or .toml).
 
     The file format is detected from the file extension.  Both formats
@@ -175,7 +174,7 @@ def load_settings(path: Union[str, Path]) -> SystemSettings:
     return SystemSettings.model_validate(raw)
 
 
-def save_settings(path: Union[str, Path], settings: SystemSettings) -> None:
+def save_settings(path: str | Path, settings: SystemSettings) -> None:
     """Write *settings* back to *path*, auto-detecting format by extension.
 
     For ``.json``: full rewrite via ``json.dumps``.

--- a/src/iv_lab/core/system.py
+++ b/src/iv_lab/core/system.py
@@ -28,10 +28,10 @@ module imports QtCore only.
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
 
 from PySide6.QtCore import QObject, QThread, Signal
 
@@ -80,9 +80,9 @@ class _MeasurementSpec:
     protocol_cls: type
     worker_cls: type
     #: Result store key ('JV', 'CV', 'CC', 'MPP'); None for calibration.
-    scan_key: Optional[str]
+    scan_key: str | None
     #: Legacy error message when saving without data.
-    no_data_message: Optional[str] = None
+    no_data_message: str | None = None
 
 
 #: Legacy scan-type labels (GUI measurement menu / system.saveData).
@@ -151,11 +151,11 @@ class IVLabSystem(QObject):
         self,
         settings: SystemSettings,
         *,
-        settings_file: Union[str, Path] = SETTINGS_FILENAME,
-        users_file: Union[str, Path] = USERS_FILENAME,
-        logo_path: Optional[Union[str, Path]] = None,
+        settings_file: str | Path = SETTINGS_FILENAME,
+        users_file: str | Path = USERS_FILENAME,
+        logo_path: str | Path | None = None,
         threaded: bool = True,
-        parent: Optional[QObject] = None,
+        parent: QObject | None = None,
     ) -> None:
         super().__init__(parent)
         self.settings = settings
@@ -169,15 +169,15 @@ class IVLabSystem(QObject):
         self.save_data_automatic = settings.IVsys.saveDataAutomatic
 
         # user table (legacy: failure is reported, login stays impossible)
-        self.authenticator: Optional[Authenticator] = None
-        self.user_table_error: Optional[str] = None
+        self.authenticator: Authenticator | None = None
+        self.user_table_error: str | None = None
         try:
             self.authenticator = Authenticator(load_users(users_file))
         except UserTableError as exc:
             self.user_table_error = str(exc)
 
         self.logbook = Logbook(settings.computer.sdPath)
-        self.user: Optional[AuthenticatedUser] = None
+        self.user: AuthenticatedUser | None = None
 
         # hardware through the factories (legacy system.__init__)
         self.smu = create_smu(settings.SMU)
@@ -194,7 +194,7 @@ class IVLabSystem(QObject):
 
         self.lamp = create_lamp(settings.lamp, smu=self.smu)
 
-        self.arduino: Optional[BaseArduino] = None
+        self.arduino: BaseArduino | None = None
         if settings.IVsys.sysName == "IV_Old":
             if settings.arduino is None:
                 raise ValueError(
@@ -207,8 +207,8 @@ class IVLabSystem(QObject):
         #: data_IV/IV_Results etc.
         self.results: dict[str, MeasurementResult] = {}
 
-        self._worker: Optional[MeasurementWorker] = None
-        self._thread: Optional[QThread] = None
+        self._worker: MeasurementWorker | None = None
+        self._thread: QThread | None = None
         self._running = False
 
     # --- hardware (legacy hardware_init) ---
@@ -278,10 +278,8 @@ class IVLabSystem(QObject):
         for device in (self.smu, self.lamp, self.arduino):
             if device is None:
                 continue
-            try:
+            with contextlib.suppress(Exception):
                 device.disconnect()
-            except Exception:
-                pass
 
     # --- authentication and logbook (legacy user_login / user_logout) ---
 
@@ -510,8 +508,6 @@ class IVLabSystem(QObject):
     def shutdown(self) -> None:
         """Abort any run, make the hardware safe, and disconnect."""
         self.abort_run()
-        try:
+        with contextlib.suppress(Exception):
             self.turn_off()
-        except Exception:
-            pass
         self.disconnect_hardware()

--- a/src/iv_lab/data/file_writer.py
+++ b/src/iv_lab/data/file_writer.py
@@ -27,9 +27,9 @@ values are runtime state on the SMU).
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional, Sequence, Union
 
 from iv_lab.data.results import (
     ConstantCurrentResults,
@@ -58,7 +58,7 @@ class SystemContext:
     #: Formatted date of the last calibration (runtime SMU state).
     calibration_datetime: str
     #: Path of the report logo (legacy EPFL_Logo.png); optional.
-    logo_path: Optional[str] = None
+    logo_path: str | None = None
 
 
 class FileWriter:
@@ -68,7 +68,7 @@ class FileWriter:
         self,
         context: SystemContext,
         *,
-        status_callback: Optional[Callable[[str], None]] = None,
+        status_callback: Callable[[str], None] | None = None,
         generate_pdf: bool = True,
     ) -> None:
         self.context = context
@@ -188,7 +188,10 @@ class FileWriter:
 
         if result.scan_type == "JV":
             for v, i, i_ref in zip(
-                result.voltage, result.current, self._reference_column(result)
+                result.voltage,
+                result.current,
+                self._reference_column(result),
+                strict=False,
             ):
                 line = str(round(v, 12)) + "," + str(round(i, 12))
                 if ctx.use_reference_diode:
@@ -200,6 +203,7 @@ class FileWriter:
                 result.voltage,
                 self._reference_column(result),
                 result.current,
+                strict=False,
             ):
                 line = (
                     str(round(t, 6))
@@ -212,7 +216,9 @@ class FileWriter:
                     line += "," + str(round(self._light_intensity(i_ref), 12))
                 lines.append(line)
         elif result.scan_type == "CC":
-            for t, v, i in zip(result.time, result.voltage, result.current):
+            for t, v, i in zip(
+                result.time, result.voltage, result.current, strict=False
+            ):
                 lines.append(
                     str(round(t, 6))
                     + ","
@@ -226,6 +232,7 @@ class FileWriter:
                 result.voltage,
                 self._reference_column(result),
                 result.current,
+                strict=False,
             ):
                 w = abs(i * v * 1000.0 / result.active_area)
                 line = (
@@ -247,11 +254,9 @@ class FileWriter:
 
     def save(
         self,
-        result: Union[
-            IVResults, ConstantVoltageResults, ConstantCurrentResults, MPPResults
-        ],
+        result: IVResults | ConstantVoltageResults | ConstantCurrentResults | MPPResults,
         username: str,
-    ) -> tuple[Path, Optional[Path]]:
+    ) -> tuple[Path, Path | None]:
         """Write the data file (and the J-V PDF report); returns
         ``(csv_path, pdf_path_or_None)``."""
         ctx = self.context
@@ -285,10 +290,10 @@ class FileWriter:
             file_string += line + "\n"
 
         data_file_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(data_file_path, "w") as f:
+        with open(data_file_path, "w", encoding="utf-8") as f:
             f.write(file_string)
 
-        pdf_path: Optional[Path] = None
+        pdf_path: Path | None = None
         if result.scan_type == "JV" and self.generate_pdf:
             from iv_lab.data.pdf_report import generate_jv_results_pdf
 
@@ -308,7 +313,7 @@ class FileWriter:
                 )
                 sd_file_path = Path(ctx.sd_path) / scrambled_filename
                 sd_file_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(sd_file_path, "w") as s:
+                with open(sd_file_path, "w", encoding="utf-8") as s:
                     s.write(scramble_string(file_string))
             except Exception:
                 pass

--- a/src/iv_lab/data/pdf_report.py
+++ b/src/iv_lab/data/pdf_report.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from iv_lab.data.results import IVResults
 
@@ -53,9 +53,9 @@ def wrap_data_file_name(data_file_name: str) -> list[tuple[str, str, str]]:
 def generate_jv_results_pdf(
     result: IVResults,
     username: str,
-    context: "SystemContext",
+    context: SystemContext,
     data_file_name: str,
-    pdf_file_path: Union[str, Path],
+    pdf_file_path: str | Path,
 ) -> Path:
     """Render the legacy J-V report PDF; returns the written path."""
     # deferred import: matplotlib is optional at package import time
@@ -109,7 +109,7 @@ def generate_jv_results_pdf(
         params_text.append(
             (
                 "Reference Calibration",
-                "{:6.4f}".format(context.full_sun_reference_current * 1000.0),
+                f"{context.full_sun_reference_current * 1000.0:6.4f}",
                 " mA",
             )
         )
@@ -137,22 +137,22 @@ def generate_jv_results_pdf(
     ]
     if result.light_int_meas is not None:
         results_text.append(
-            ("Measured Intensity", "{:6.2f}".format(result.light_int_meas), "% sun")
+            ("Measured Intensity", f"{result.light_int_meas:6.2f}", "% sun")
         )
     if result.Jsc is not None:
-        results_text.append(("Jsc", "{:5.3f}".format(result.Jsc), " mA/$cm^2$"))
+        results_text.append(("Jsc", f"{result.Jsc:5.3f}", " mA/$cm^2$"))
     if result.Voc is not None:
-        results_text.append(("Voc", "{:6.4f}".format(result.Voc), "V"))
+        results_text.append(("Voc", f"{result.Voc:6.4f}", "V"))
     if result.FF is not None:
-        results_text.append(("FF", "{:6.4f}".format(result.FF), ""))
+        results_text.append(("FF", f"{result.FF:6.4f}", ""))
     if result.PCE is not None:
-        results_text.append(("PCE", "{:5.2f}".format(result.PCE), "%"))
+        results_text.append(("PCE", f"{result.PCE:5.2f}", "%"))
     if result.Jmpp is not None:
-        results_text.append(("Jmpp", "{:5.3f}".format(result.Jmpp), " mA/$cm^2$"))
+        results_text.append(("Jmpp", f"{result.Jmpp:5.3f}", " mA/$cm^2$"))
     if result.Vmpp is not None:
-        results_text.append(("Vmpp", "{:6.4f}".format(result.Vmpp), "V"))
+        results_text.append(("Vmpp", f"{result.Vmpp:6.4f}", "V"))
     if result.Pmpp is not None:
-        results_text.append(("Pmpp", "{:7.3f}".format(result.Pmpp), " mW/$cm^2$"))
+        results_text.append(("Pmpp", f"{result.Pmpp:7.3f}", " mW/$cm^2$"))
 
     for label, value, units in results_text:
         fig.text(rt_x1, rt_y, label, fontsize=10, ha="left")

--- a/src/iv_lab/data/results.py
+++ b/src/iv_lab/data/results.py
@@ -26,8 +26,9 @@ no dedicated field.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, Union
+from typing import Any
 
 #: Legacy units: voltages in V, currents in A, time in s, active area in cm².
 Array = Sequence[float]
@@ -43,16 +44,16 @@ class MeasurementResult:
     #: Legacy ``scanType`` tag ('JV', 'CV', 'CC', 'MPP'); set per subclass.
     scan_type: str = ""
     #: Measurement start time, legacy formatted string (``data_*['start_time']``).
-    start_time: Optional[str] = None
-    cell_name: Optional[str] = None
+    start_time: str | None = None
+    cell_name: str | None = None
     #: Active cell area in cm².
-    active_area: Optional[float] = None
+    active_area: float | None = None
     #: Requested light intensity in percent of one sun (``light_int``).
-    light_int: Optional[float] = None
+    light_int: float | None = None
     #: Measured light intensity in percent of one sun (``light_int_meas``).
-    light_int_meas: Optional[float] = None
+    light_int_meas: float | None = None
     #: Sense wiring, 2 or 4 (legacy ``Nwire``).
-    Nwire: Optional[int] = None
+    Nwire: int | None = None
     #: Extra legacy metadata preserved for the file writer.
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -64,26 +65,26 @@ class IVResults(MeasurementResult):
     scan_type: str = "JV"
 
     # scan parameters (legacy key spelling)
-    start_V: Optional[Union[float, str]] = None  # may be 'Voc' in legacy
-    stop_V: Optional[Union[float, str]] = None  # may be 'Voc' in legacy
-    dV: Optional[float] = None
-    sweep_rate: Optional[float] = None
-    Imax: Optional[float] = None
-    Dwell: Optional[float] = None
+    start_V: float | str | None = None  # may be 'Voc' in legacy
+    stop_V: float | str | None = None  # may be 'Voc' in legacy
+    dV: float | None = None
+    sweep_rate: float | None = None
+    Imax: float | None = None
+    Dwell: float | None = None
 
     # data arrays (legacy data_IV['v'], ['i'], ['i_ref'])
     voltage: Array = field(default_factory=list)
     current: Array = field(default_factory=list)
-    current_reference: Optional[Array] = None
+    current_reference: Array | None = None
 
     # photovoltaic metrics (legacy key spelling)
-    Voc: Optional[float] = None
-    Jsc: Optional[float] = None
-    Vmpp: Optional[float] = None
-    Jmpp: Optional[float] = None
-    Pmpp: Optional[float] = None
-    PCE: Optional[float] = None
-    FF: Optional[float] = None
+    Voc: float | None = None
+    Jsc: float | None = None
+    Vmpp: float | None = None
+    Jmpp: float | None = None
+    Pmpp: float | None = None
+    PCE: float | None = None
+    FF: float | None = None
 
 
 @dataclass
@@ -93,15 +94,15 @@ class ConstantVoltageResults(MeasurementResult):
 
     scan_type: str = "CV"
 
-    set_voltage: Optional[float] = None
-    interval: Optional[float] = None
-    duration: Optional[float] = None
+    set_voltage: float | None = None
+    interval: float | None = None
+    duration: float | None = None
 
     # data arrays (legacy data_CV['t'], ['v'], ['i'], ['i_ref'])
     time: Array = field(default_factory=list)
     voltage: Array = field(default_factory=list)
     current: Array = field(default_factory=list)
-    current_reference: Optional[Array] = None
+    current_reference: Array | None = None
 
 
 @dataclass
@@ -111,15 +112,15 @@ class ConstantCurrentResults(MeasurementResult):
 
     scan_type: str = "CC"
 
-    set_current: Optional[float] = None
-    interval: Optional[float] = None
-    duration: Optional[float] = None
+    set_current: float | None = None
+    interval: float | None = None
+    duration: float | None = None
 
     # data arrays (legacy data_CC['t'], ['v'], ['i'])
     time: Array = field(default_factory=list)
     voltage: Array = field(default_factory=list)
     current: Array = field(default_factory=list)
-    current_reference: Optional[Array] = None
+    current_reference: Array | None = None
 
 
 @dataclass
@@ -130,15 +131,15 @@ class MPPResults(MeasurementResult):
     scan_type: str = "MPP"
 
     #: Legacy ``start_voltage``; may be 'auto' to start from a J-V scan.
-    start_voltage: Optional[Union[float, str]] = None
-    interval: Optional[float] = None
-    duration: Optional[float] = None
+    start_voltage: float | str | None = None
+    interval: float | None = None
+    duration: float | None = None
 
     # data arrays (legacy data_MPP['t'], ['v'], ['i'], ['i_ref'])
     time: Array = field(default_factory=list)
     voltage: Array = field(default_factory=list)
     current: Array = field(default_factory=list)
-    current_reference: Optional[Array] = None
+    current_reference: Array | None = None
 
 
 @dataclass
@@ -154,15 +155,15 @@ class CalibrationResults(MeasurementResult):
 
     scan_type: str = "Calibration"
 
-    interval: Optional[float] = None
-    duration: Optional[float] = None
+    interval: float | None = None
+    duration: float | None = None
 
     # data arrays (time, cell/diode current, reference diode current)
     time: Array = field(default_factory=list)
     current: Array = field(default_factory=list)
-    current_reference: Optional[Array] = None
+    current_reference: Array | None = None
 
     #: Derived full-sun reference current in A (``fullSunReferenceCurrent``).
-    reference_current: Optional[float] = None
+    reference_current: float | None = None
     #: Legacy formatted calibration date string (``calibrationDateTime``).
-    calibration_datetime: Optional[str] = None
+    calibration_datetime: str | None = None

--- a/src/iv_lab/gui/app.py
+++ b/src/iv_lab/gui/app.py
@@ -8,7 +8,6 @@ docs/MIGRATION.md).
 from __future__ import annotations
 
 import sys
-from typing import Optional
 
 from PySide6.QtWidgets import QApplication
 
@@ -17,7 +16,7 @@ from iv_lab.core import IVLabSystem
 from iv_lab.gui.main_window import MainWindow
 
 
-def create_application(argv: Optional[list[str]] = None) -> QApplication:
+def create_application(argv: list[str] | None = None) -> QApplication:
     """Return the process-wide ``QApplication`` (created on demand)."""
     app = QApplication.instance()
     if app is None:

--- a/src/iv_lab/gui/main_window.py
+++ b/src/iv_lab/gui/main_window.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Optional
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
@@ -51,7 +50,7 @@ USER_CONFIG_FILENAME = "IVLab_config.json"
 class MainWindow(QMainWindow):
     """IVLab main window wired to the core system."""
 
-    def __init__(self, system: IVLabSystem, parent: Optional[QWidget] = None) -> None:
+    def __init__(self, system: IVLabSystem, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.system = system
         #: Tests set this to avoid modal error dialogs.
@@ -389,7 +388,7 @@ class MainWindow(QMainWindow):
             "sweepDirection": panel.menu_sweep_direction,
         }
 
-    def _user_config_path(self) -> Optional[str]:
+    def _user_config_path(self) -> str | None:
         if self.system.user is None:
             return None
         return os.path.join(
@@ -418,7 +417,7 @@ class MainWindow(QMainWindow):
 
         try:
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, "w") as outfile:
+            with open(path, "w", encoding="utf-8") as outfile:
                 json.dump(config, outfile)
         except Exception:
             self._show_error("ERROR: Could not create settings file " + path)
@@ -429,7 +428,7 @@ class MainWindow(QMainWindow):
         if path is None or not os.path.exists(path):
             return
         try:
-            with open(path) as config_file:
+            with open(path, encoding="utf-8") as config_file:
                 config = json.load(config_file)
         except Exception:
             return

--- a/src/iv_lab/gui/panels/calibration_panel.py
+++ b/src/iv_lab/gui/panels/calibration_panel.py
@@ -80,7 +80,7 @@ class CalibrationPanel(QWidget):
     def set_reference_current(self, current_ma: float) -> None:
         """Show the derived current (legacy ``setCalibrationReferenceCurrent``,
         ``{:5.3f}`` in mA)."""
-        self.field_reference_cell_current.setText("{:5.3f}".format(current_ma))
+        self.field_reference_cell_current.setText(f"{current_ma:5.3f}")
 
     def reference_current_a(self) -> float:
         """Field value converted to A (legacy ``saveCalibration``)."""

--- a/src/iv_lab/gui/panels/light_panel.py
+++ b/src/iv_lab/gui/panels/light_panel.py
@@ -93,5 +93,5 @@ class LightLevelPanel(QGroupBox):
     def update_measured_intensity(self, intensity: float) -> None:
         """Legacy ``updateMeasuredLightIntensity``."""
         self.label_measured_intensity.setText(
-            "Measured Light Intensity: " + "{:6.2f}".format(intensity) + "% sun"
+            "Measured Light Intensity: " + f"{intensity:6.2f}" + "% sun"
         )

--- a/src/iv_lab/gui/panels/measurement_panel.py
+++ b/src/iv_lab/gui/panels/measurement_panel.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QDoubleValidator
@@ -98,7 +98,7 @@ class MeasurementPanel(QWidget):
         self,
         light_level_provider: Callable[[], float],
         cell_name_provider: Callable[[], str],
-        parent: Optional[QWidget] = None,
+        parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._light_level = light_level_provider

--- a/src/iv_lab/gui/panels/plot_panel.py
+++ b/src/iv_lab/gui/panels/plot_panel.py
@@ -13,8 +13,6 @@ automatic start scan).
 
 from __future__ import annotations
 
-from typing import Optional
-
 import pyqtgraph as pg
 from PySide6.QtWidgets import (
     QGridLayout,
@@ -97,7 +95,7 @@ class _ResultField(QHBoxLayout):
 class PlotPanel(QWidget):
     """Stacked measurement plots plus the J-V results grid."""
 
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.stack = QStackedWidget()
 
@@ -222,7 +220,7 @@ class PlotPanel(QWidget):
 
     # --- J-V results grid (legacy updateIVResults) ---
 
-    def update_iv_results(self, result: Optional[IVResults]) -> None:
+    def update_iv_results(self, result: IVResults | None) -> None:
         def fmt(value, spec):
             return spec.format(value) if value is not None else "-----"
 

--- a/src/iv_lab/hardware/arduino/registry.py
+++ b/src/iv_lab/hardware/arduino/registry.py
@@ -8,7 +8,8 @@ driver is not registered; the factory selects it directly.
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 from .base import BaseArduino
 

--- a/src/iv_lab/hardware/lamp/base.py
+++ b/src/iv_lab/hardware/lamp/base.py
@@ -24,7 +24,7 @@ hardware imports (``pyvisa``, ``pytrinamic``) into connection-time code.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional, Union
+from typing import Any
 
 from iv_lab.config import LampSettings
 from iv_lab.hardware.base import HardwareDevice
@@ -43,7 +43,7 @@ class BaseLamp(HardwareDevice):
     def __init__(
         self,
         settings: LampSettings,
-        smu: Optional[BaseSMU] = None,
+        smu: BaseSMU | None = None,
         name: str = "",
     ) -> None:
         super().__init__(name or settings.display_name or "")
@@ -51,7 +51,7 @@ class BaseLamp(HardwareDevice):
         self.smu = smu
         #: Light level in % sun -> recipe name / wheel angle / filter code
         #: (legacy ``lightLevelDict``; ``None`` only for the manual lamp).
-        self.light_level_dict: Optional[dict[float, Union[int, float, str]]] = (
+        self.light_level_dict: dict[float, int | float | str] | None = (
             settings.lightLevelDict
         )
         #: Whether the light is currently considered on (legacy ``light_is_on``).

--- a/src/iv_lab/hardware/lamp/drivers/__init__.py
+++ b/src/iv_lab/hardware/lamp/drivers/__init__.py
@@ -8,9 +8,11 @@ is safe on machines without them installed.
 The emulated driver does not register; the factory selects it directly.
 """
 
-from . import keithley_filter  # noqa: F401
-from . import manual  # noqa: F401
-from . import oriel  # noqa: F401
-from . import trinamic  # noqa: F401
-from . import verasol  # noqa: F401
-from . import wavelabs  # noqa: F401
+from . import (
+    keithley_filter,  # noqa: F401
+    manual,  # noqa: F401
+    oriel,  # noqa: F401
+    trinamic,  # noqa: F401
+    verasol,  # noqa: F401
+    wavelabs,  # noqa: F401
+)

--- a/src/iv_lab/hardware/lamp/drivers/_verasol_lib.py
+++ b/src/iv_lab/hardware/lamp/drivers/_verasol_lib.py
@@ -17,7 +17,6 @@ import time
 import warnings
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 try:
     import pyvisa
@@ -30,7 +29,8 @@ except ImportError as exc:  # pragma: no cover
 if sys.platform == "win32":
     import ctypes
     import winreg
-    from ctypes import windll, create_string_buffer, c_ulong, byref as _byref
+    from ctypes import byref as _byref
+    from ctypes import c_ulong, create_string_buffer, windll
     _WIN32_AVAILABLE = True
 else:
     _WIN32_AVAILABLE = False
@@ -177,7 +177,7 @@ class _WinUSBTMC:
         return self.read()
 
 
-def _find_win_usbtmc_device(idn_hint: str = _VERASOL_IDN_HINT) -> Optional[str]:
+def _find_win_usbtmc_device(idn_hint: str = _VERASOL_IDN_HINT) -> str | None:
     """
     Search the Windows device-interface registry for a USBTMC instrument whose
     ``*IDN?`` response contains *idn_hint*.  Returns the Win32 device path on
@@ -242,7 +242,7 @@ class VeraSol:
 
     def __init__(
         self,
-        resource_name: Optional[str] = None,
+        resource_name: str | None = None,
         timeout_ms: int = 10_000,
     ) -> None:
         self._rm = None
@@ -288,7 +288,7 @@ class VeraSol:
     # Context manager
     # ------------------------------------------------------------------
 
-    def __enter__(self) -> "VeraSol":
+    def __enter__(self) -> VeraSol:
         return self
 
     def __exit__(self, *_) -> None:

--- a/src/iv_lab/hardware/lamp/drivers/emulated.py
+++ b/src/iv_lab/hardware/lamp/drivers/emulated.py
@@ -9,8 +9,6 @@ same for any configured brand.
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.config import LampSettings
 from iv_lab.hardware.smu.base import BaseSMU
 
@@ -20,7 +18,7 @@ from ..base import BaseLamp
 class EmulatedLamp(BaseLamp):
     """In-memory lamp tracking light level and on/off state."""
 
-    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+    def __init__(self, settings: LampSettings, smu: BaseSMU | None = None) -> None:
         super().__init__(settings, smu=smu, name=f"Emulated {settings.display_name}")
 
     def _open(self) -> None:

--- a/src/iv_lab/hardware/lamp/drivers/keithley_filter.py
+++ b/src/iv_lab/hardware/lamp/drivers/keithley_filter.py
@@ -15,7 +15,6 @@ time for the wheel to reach position (11 s after ``light_on``, 7 s after
 from __future__ import annotations
 
 import time
-from typing import Optional
 
 from iv_lab.config import LampSettings
 from iv_lab.hardware.errors import HardwareConnectionError
@@ -33,7 +32,7 @@ LIGHT_OFF_WAIT = 7.0
 class KeithleyFilterWheelLamp(BaseLamp):
     """Filter wheel driven by the SMU's digital output lines."""
 
-    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+    def __init__(self, settings: LampSettings, smu: BaseSMU | None = None) -> None:
         super().__init__(settings, smu=smu)
         self.light_on_wait = LIGHT_ON_WAIT
         self.light_off_wait = LIGHT_OFF_WAIT

--- a/src/iv_lab/hardware/lamp/drivers/oriel.py
+++ b/src/iv_lab/hardware/lamp/drivers/oriel.py
@@ -12,8 +12,6 @@ verification tolerances).
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.config import LampSettings
 from iv_lab.hardware.errors import HardwareCommandError, HardwareConnectionError
 from iv_lab.hardware.smu.base import BaseSMU
@@ -29,7 +27,7 @@ ORIEL_IDN_PREFIX = "Newport Corporation,LSS-7120"
 class OrielLSS7120Lamp(BaseLamp):
     """Oriel LSS-7120 driven over VISA."""
 
-    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+    def __init__(self, settings: LampSettings, smu: BaseSMU | None = None) -> None:
         super().__init__(settings, smu=smu)
         if settings.visa_address is None:
             raise ValueError("Oriel LSS-7120 lamp requires a 'visa_address' setting")

--- a/src/iv_lab/hardware/lamp/drivers/trinamic.py
+++ b/src/iv_lab/hardware/lamp/drivers/trinamic.py
@@ -17,7 +17,6 @@ option for the TMCM-1160 only when homing, not when moving — preserved).
 from __future__ import annotations
 
 import time
-from typing import Optional
 
 from iv_lab.config import LampSettings
 from iv_lab.hardware.errors import HardwareConnectionError, HardwareTimeoutError
@@ -35,7 +34,7 @@ TRINAMIC_MOVE_TIMEOUT = 12.0
 class TrinamicFilterWheelLamp(BaseLamp):
     """Filter wheel on a Trinamic stepper motor module."""
 
-    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+    def __init__(self, settings: LampSettings, smu: BaseSMU | None = None) -> None:
         super().__init__(settings, smu=smu)
         self.model = settings.model
 
@@ -48,7 +47,7 @@ class TrinamicFilterWheelLamp(BaseLamp):
         # motor parameters; microstep resolution is read from the motor
         # enum on connect (legacy stored MicrostepResolution256Microsteps)
         self.steps_per_revolution = 200
-        self.microstep_resolution: Optional[int] = None
+        self.microstep_resolution: int | None = None
 
         self._connection_manager_cls = None
         self._module_cls = None

--- a/src/iv_lab/hardware/lamp/drivers/verasol.py
+++ b/src/iv_lab/hardware/lamp/drivers/verasol.py
@@ -20,8 +20,6 @@ amplitude in its operating range directly from ``light_int``.
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.config import LampSettings
 from iv_lab.hardware.errors import HardwareCommandError, HardwareConnectionError
 from iv_lab.hardware.smu.base import BaseSMU
@@ -37,10 +35,10 @@ _MIN_SUNS = 0.1   # instrument minimum amplitude
 class VeraSolLamp(BaseLamp):
     """Oriel VeraSol LSS-7120 LED solar simulator (USB/USBTMC)."""
 
-    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+    def __init__(self, settings: LampSettings, smu: BaseSMU | None = None) -> None:
         super().__init__(settings, smu=smu)
         # None / empty string both trigger auto-discovery in _verasol_lib.VeraSol
-        self._visa_address: Optional[str] = settings.visa_address or None
+        self._visa_address: str | None = settings.visa_address or None
         self._lamp = None
 
     # ------------------------------------------------------------------

--- a/src/iv_lab/hardware/lamp/drivers/wavelabs.py
+++ b/src/iv_lab/hardware/lamp/drivers/wavelabs.py
@@ -20,7 +20,6 @@ optional hardware dependency.
 from __future__ import annotations
 
 import socket
-from typing import Optional
 
 from iv_lab.config import LampSettings
 from iv_lab.hardware.errors import HardwareCommandError
@@ -37,7 +36,7 @@ WAVELABS_ADDRESS = ("127.0.0.1", 55555)
 class WavelabsLamp(BaseLamp):
     """Wavelabs Sinus70 driven through its WLRC TCP protocol."""
 
-    def __init__(self, settings: LampSettings, smu: Optional[BaseSMU] = None) -> None:
+    def __init__(self, settings: LampSettings, smu: BaseSMU | None = None) -> None:
         super().__init__(settings, smu=smu)
         self.connection_open = False
         self.seq_num = 0

--- a/src/iv_lab/hardware/lamp/factory.py
+++ b/src/iv_lab/hardware/lamp/factory.py
@@ -7,8 +7,6 @@ digital output lines (legacy ``lamp(..., smu=self.SMU)``).
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.config import LampSettings
 from iv_lab.hardware.smu.base import BaseSMU
 
@@ -16,7 +14,7 @@ from .base import BaseLamp
 from .registry import get_lamp_driver
 
 
-def create_lamp(settings: LampSettings, smu: Optional[BaseSMU] = None) -> BaseLamp:
+def create_lamp(settings: LampSettings, smu: BaseSMU | None = None) -> BaseLamp:
     """Create a lamp driver instance for the given settings.
 
     Returns the emulated driver when ``settings.emulate`` is set;

--- a/src/iv_lab/hardware/lamp/registry.py
+++ b/src/iv_lab/hardware/lamp/registry.py
@@ -11,7 +11,8 @@ when ``emulate`` is set.
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 from .base import BaseLamp
 

--- a/src/iv_lab/hardware/smu/drivers/__init__.py
+++ b/src/iv_lab/hardware/smu/drivers/__init__.py
@@ -10,5 +10,7 @@ The emulated driver does not register; the factory selects it directly.
 
 # Real driver modules are imported here as they are migrated, so that
 # their registry decorators run.
-from . import keithley_2400  # noqa: F401
-from . import keithley_26xx  # noqa: F401
+from . import (
+    keithley_26xx,  # noqa: F401
+    keithley_2400,  # noqa: F401
+)

--- a/src/iv_lab/hardware/smu/drivers/emulated.py
+++ b/src/iv_lab/hardware/smu/drivers/emulated.py
@@ -24,7 +24,6 @@ import math
 import random
 import time
 from dataclasses import dataclass
-from typing import Optional
 
 from iv_lab.config import SMUSettings
 
@@ -53,11 +52,12 @@ class _ChannelState:
 class EmulatedSMU(BaseSMU):
     """In-memory SMU presenting a diode-shaped solar cell on both channels."""
 
-    def __init__(self, settings: Optional[SMUSettings] = None) -> None:
-        if settings is None:
-            name = "Emulated SMU"
-        else:
-            name = f"Emulated {settings.brand} {settings.model}"
+    def __init__(self, settings: SMUSettings | None = None) -> None:
+        name = (
+            "Emulated SMU"
+            if settings is None
+            else f"Emulated {settings.brand} {settings.model}"
+        )
         super().__init__(name)
 
         self.settings = settings

--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -31,6 +31,7 @@ Preserved legacy quirks:
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 
 from iv_lab.config import SMUSettings
@@ -176,10 +177,8 @@ class Keithley2400FamilySMU(BaseSMU):
         # no explicit disconnect in pymeasure; disable the output in case
         # it is enabled, then close the adapter (legacy disconnect)
         self.smu.disable_source()
-        try:
+        with contextlib.suppress(Exception):
             self.smu.adapter.close()
-        except Exception:
-            pass
 
     # --- channel switching (legacy toggle_output_2400) ---
 

--- a/src/iv_lab/hardware/smu/registry.py
+++ b/src/iv_lab/hardware/smu/registry.py
@@ -11,7 +11,8 @@ registered here — the factory selects it directly when ``emulate`` is set.
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 from .base import BaseSMU
 

--- a/src/iv_lab/main.py
+++ b/src/iv_lab/main.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Optional
-
 from pathlib import Path
 
 from iv_lab.config import DEFAULT_SETTINGS_FILENAME, load_settings
@@ -29,7 +27,7 @@ from iv_lab.services.auth import USERS_FILENAME, USERS_GENERIC_FILENAME
 DEFAULT_LOGO_FILENAME = "EPFL_Logo.png"
 
 
-def resolve_users_file(explicit: Optional[str]) -> Path:
+def resolve_users_file(explicit: str | None) -> Path:
     """Return the users file to load, applying the fallback chain.
 
     Priority: explicit --users arg → config/users.txt (if exists) → config/users_generic.txt
@@ -42,7 +40,7 @@ def resolve_users_file(explicit: Optional[str]) -> Path:
     return Path(USERS_GENERIC_FILENAME)
 
 
-def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="iv_lab",
         description="IV characterization lab application (EPFL LPI).",
@@ -73,7 +71,7 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: Optional[list[str]] = None, *, exec_app: bool = True) -> int:
+def main(argv: list[str] | None = None, *, exec_app: bool = True) -> int:
     """Run the application; returns the process exit code.
 
     ``exec_app=False`` skips the Qt event loop (used by tests).

--- a/src/iv_lab/measurements/protocols/base.py
+++ b/src/iv_lab/measurements/protocols/base.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any
 
 from iv_lab.hardware.arduino.base import BaseArduino
 from iv_lab.hardware.lamp.base import BaseLamp
@@ -42,7 +43,7 @@ class VocPolarityError(Exception):
     """Wrong Voc polarity detected before a scan (legacy abort case)."""
 
 
-def _nwire_value(nwire: Union[int, str]) -> int:
+def _nwire_value(nwire: int | str) -> int:
     """Map the legacy ``Nwire`` parameter to 2 or 4.
 
     The legacy GUI passes ``'2 wire'`` / ``'4 wire'`` strings; the legacy
@@ -70,14 +71,14 @@ class MeasurementProtocol(ABC):
         self,
         smu: BaseSMU,
         lamp: BaseLamp,
-        arduino: Optional[BaseArduino] = None,
+        arduino: BaseArduino | None = None,
         *,
         system_name: str = "",
         check_voc_before_scan: bool = True,
-        status_callback: Optional[Callable[[str], None]] = None,
-        warning_callback: Optional[Callable[[str], None]] = None,
-        data_callback: Optional[Callable[[dict], None]] = None,
-        cancel_callback: Optional[Callable[[], bool]] = None,
+        status_callback: Callable[[str], None] | None = None,
+        warning_callback: Callable[[str], None] | None = None,
+        data_callback: Callable[[dict], None] | None = None,
+        cancel_callback: Callable[[], bool] | None = None,
     ) -> None:
         self.smu = smu
         self.lamp = lamp
@@ -90,7 +91,7 @@ class MeasurementProtocol(ABC):
         self._warning_callback = warning_callback
         self._data_callback = data_callback
         self._cancel_callback = cancel_callback
-        self._confirm_callback: Optional[Callable[[str, float], bool]] = None
+        self._confirm_callback: Callable[[str, float], bool] | None = None
 
         #: Legacy ``system.measure_light_intensity`` measured for 5 s.
         self.light_intensity_measure_time = 5.0
@@ -105,11 +106,11 @@ class MeasurementProtocol(ABC):
     def set_callbacks(
         self,
         *,
-        status: Optional[Callable[[str], None]] = None,
-        warning: Optional[Callable[[str], None]] = None,
-        data: Optional[Callable[[dict], None]] = None,
-        cancel: Optional[Callable[[], bool]] = None,
-        confirm: Optional[Callable[[str, float], bool]] = None,
+        status: Callable[[str], None] | None = None,
+        warning: Callable[[str], None] | None = None,
+        data: Callable[[dict], None] | None = None,
+        cancel: Callable[[], bool] | None = None,
+        confirm: Callable[[str, float], bool] | None = None,
     ) -> None:
         """Attach or replace the interaction callbacks.
 

--- a/src/iv_lab/measurements/protocols/calibration.py
+++ b/src/iv_lab/measurements/protocols/calibration.py
@@ -64,10 +64,7 @@ class CalibrationProtocol(MeasurementProtocol):
         smu.set_voltage_limit(SMUChannel.CELL, p["Vmax"])
         smu.set_current_limit(SMUChannel.CELL, p["Imax"])
 
-        if smu.reference_diode_parallel:
-            channel_list = ["BOTH"]
-        else:
-            channel_list = ["A", "B"]
+        channel_list = ["BOTH"] if smu.reference_diode_parallel else ["A", "B"]
 
         for channel in channel_list:
             if abs(p["set_voltage"]) > abs(p["Vmax"]):
@@ -84,7 +81,7 @@ class CalibrationProtocol(MeasurementProtocol):
                 smu.setup_reference_diode()
                 smu.enable_output(SMUChannel.REFERENCE)
 
-            def measure() -> tuple:
+            def measure(channel: str = channel) -> tuple:
                 if channel == "A":
                     return (smu.measure_current(SMUChannel.CELL), None)
                 if channel == "B":

--- a/src/iv_lab/measurements/protocols/constant_current.py
+++ b/src/iv_lab/measurements/protocols/constant_current.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import datetime
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from iv_lab.data import ConstantCurrentResults
 from iv_lab.hardware.smu.base import BaseSMU, SMUChannel

--- a/src/iv_lab/measurements/protocols/constant_voltage.py
+++ b/src/iv_lab/measurements/protocols/constant_voltage.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import datetime
 import time
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from iv_lab.data import ConstantVoltageResults
 from iv_lab.hardware.smu.base import BaseSMU, SMUChannel
@@ -149,7 +149,7 @@ class ConstantVoltageProtocol(MeasurementProtocol):
 
         self.status("Turning lamp on...")
         self.turn_lamp_on(p["light_int"])
-        light_intensity: Optional[float] = None
+        light_intensity: float | None = None
         try:
             if self.smu.use_reference_diode:
                 light_intensity = self.check_light_level(p["light_int"])

--- a/src/iv_lab/measurements/protocols/iv_curve.py
+++ b/src/iv_lab/measurements/protocols/iv_curve.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import datetime
 import time
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from iv_lab.analysis.jv_metrics import JVMetrics, compute_jv_metrics, pce
 from iv_lab.data import IVResults
@@ -168,7 +168,7 @@ class IVCurveProtocol(MeasurementProtocol):
     injectable for headless tests without pandas/bric installed.
     """
 
-    def __init__(self, *args, metrics_function: Optional[MetricsFunction] = None, **kwargs) -> None:
+    def __init__(self, *args, metrics_function: MetricsFunction | None = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._metrics_function = metrics_function or compute_jv_metrics
 
@@ -228,7 +228,7 @@ class IVCurveProtocol(MeasurementProtocol):
 
         self.status("Turning lamp on...")
         self.turn_lamp_on(p["light_int"])
-        light_intensity: Optional[float] = None
+        light_intensity: float | None = None
         try:
             # measure light intensity on the reference diode if configured
             if self.smu.use_reference_diode:

--- a/src/iv_lab/measurements/protocols/mpp_tracking.py
+++ b/src/iv_lab/measurements/protocols/mpp_tracking.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import datetime
 import time
-from typing import Optional
 
 from iv_lab.data import MPPResults
 from iv_lab.hardware.smu.base import SMUChannel
@@ -93,7 +92,7 @@ class MPPTrackingProtocol(MeasurementProtocol):
         )
 
         # cell voltage is positive, current negative: maximize -v*i (legacy)
-        p_smu = [v * i * -1 for v, i in zip(v_smu, i_smu)]
+        p_smu = [v * i * -1 for v, i in zip(v_smu, i_smu, strict=False)]
         max_power = max(p_smu)
         return v_smu[p_smu.index(max_power)]
 
@@ -250,7 +249,7 @@ class MPPTrackingProtocol(MeasurementProtocol):
 
         self.status("Turning lamp on...")
         self.turn_lamp_on(p["light_int"])
-        light_intensity: Optional[float] = None
+        light_intensity: float | None = None
         try:
             if self.smu.use_reference_diode:
                 light_intensity = self.check_light_level(p["light_int"])

--- a/src/iv_lab/measurements/workers/base_worker.py
+++ b/src/iv_lab/measurements/workers/base_worker.py
@@ -28,7 +28,6 @@ to the constructor), never write files, and import QtCore only.
 from __future__ import annotations
 
 import threading
-from typing import Optional
 
 from PySide6.QtCore import QObject, Signal, Slot
 
@@ -54,7 +53,7 @@ class MeasurementWorker(QObject):
         self,
         protocol: MeasurementProtocol,
         params: dict,
-        parent: Optional[QObject] = None,
+        parent: QObject | None = None,
     ) -> None:
         super().__init__(parent)
         if not isinstance(protocol, self.protocol_class):
@@ -119,7 +118,7 @@ class MeasurementWorker(QObject):
 
     # --- progress derivation ---
 
-    def _progress_from_data(self, data: dict) -> Optional[int]:
+    def _progress_from_data(self, data: dict) -> int | None:
         """Derive percent complete from a live data dict; None = unknown.
 
         Overridden by concrete workers. Time-based measurements derive
@@ -133,7 +132,7 @@ class MeasurementWorker(QObject):
         if progress is not None:
             self.progress_update.emit(max(0, min(100, int(progress))))
 
-    def _time_progress(self, data: dict) -> Optional[int]:
+    def _time_progress(self, data: dict) -> int | None:
         """Progress for duration-based protocols from the time axis."""
         times = data.get("t")
         duration = self.params.get("duration")

--- a/src/iv_lab/measurements/workers/calibration_worker.py
+++ b/src/iv_lab/measurements/workers/calibration_worker.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.measurements.protocols.calibration import CalibrationProtocol
 
 from .base_worker import MeasurementWorker
@@ -16,7 +14,7 @@ class CalibrationWorker(MeasurementWorker):
 
     protocol_class = CalibrationProtocol
 
-    def _progress_from_data(self, data: dict) -> Optional[int]:
+    def _progress_from_data(self, data: dict) -> int | None:
         # use whichever time axis is advancing; the serial and IV_Old
         # modes run two passes, so this intentionally reaches 100% twice
         times = data.get("t_ref") or data.get("t_meas") or data.get("t")

--- a/src/iv_lab/measurements/workers/constant_current_worker.py
+++ b/src/iv_lab/measurements/workers/constant_current_worker.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.measurements.protocols.constant_current import ConstantCurrentProtocol
 
 from .base_worker import MeasurementWorker
@@ -15,5 +13,5 @@ class ConstantCurrentWorker(MeasurementWorker):
 
     protocol_class = ConstantCurrentProtocol
 
-    def _progress_from_data(self, data: dict) -> Optional[int]:
+    def _progress_from_data(self, data: dict) -> int | None:
         return self._time_progress(data)

--- a/src/iv_lab/measurements/workers/constant_voltage_worker.py
+++ b/src/iv_lab/measurements/workers/constant_voltage_worker.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.measurements.protocols.constant_voltage import ConstantVoltageProtocol
 
 from .base_worker import MeasurementWorker
@@ -15,5 +13,5 @@ class ConstantVoltageWorker(MeasurementWorker):
 
     protocol_class = ConstantVoltageProtocol
 
-    def _progress_from_data(self, data: dict) -> Optional[int]:
+    def _progress_from_data(self, data: dict) -> int | None:
         return self._time_progress(data)

--- a/src/iv_lab/measurements/workers/iv_curve_worker.py
+++ b/src/iv_lab/measurements/workers/iv_curve_worker.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.measurements.protocols.iv_curve import IVCurveProtocol
 
 from .base_worker import MeasurementWorker
@@ -14,7 +12,7 @@ class IVCurveWorker(MeasurementWorker):
 
     protocol_class = IVCurveProtocol
 
-    def _progress_from_data(self, data: dict) -> Optional[int]:
+    def _progress_from_data(self, data: dict) -> int | None:
         # progress along the voltage span; unknown for 'Voc' limits
         voltages = data.get("v")
         start = self.params.get("start_V")

--- a/src/iv_lab/measurements/workers/mpp_tracking_worker.py
+++ b/src/iv_lab/measurements/workers/mpp_tracking_worker.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from iv_lab.measurements.protocols.mpp_tracking import MPPTrackingProtocol
 
 from .base_worker import MeasurementWorker
@@ -16,7 +14,7 @@ class MPPTrackingWorker(MeasurementWorker):
 
     protocol_class = MPPTrackingProtocol
 
-    def _progress_from_data(self, data: dict) -> Optional[int]:
+    def _progress_from_data(self, data: dict) -> int | None:
         # the auto-start J-V scan emits {'v','j'} dicts with no time axis;
         # report indeterminate progress for those
         return self._time_progress(data)

--- a/src/iv_lab/services/auth.py
+++ b/src/iv_lab/services/auth.py
@@ -33,7 +33,6 @@ import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
 
 #: Machine-specific live users file (gitignored; takes priority if it exists).
 USERS_FILENAME = "config/users.txt"
@@ -82,7 +81,7 @@ def scramble_string(text: str) -> str:
     for i, b in enumerate(bytename):
         hashed_bytes.append((hashed_bytes[i] + b) % 256)
 
-    return "".join("{:02x}".format(b) for b in hashed_bytes)
+    return "".join(f"{b:02x}" for b in hashed_bytes)
 
 
 def unscramble_string(text: str) -> str:
@@ -104,7 +103,7 @@ def unscramble_string(text: str) -> str:
     return bytearray(reversed(unhashed_reversed)).decode()
 
 
-def load_users(path: Union[str, Path]) -> dict[str, str]:
+def load_users(path: str | Path) -> dict[str, str]:
     """Load the scrambled JSON user table (legacy ``system.__init__``).
 
     Returns a username -> password mapping with lowercase usernames.
@@ -112,7 +111,7 @@ def load_users(path: Union[str, Path]) -> dict[str, str]:
     is missing or cannot be decoded.
     """
     try:
-        scrambled = Path(path).read_text()
+        scrambled = Path(path).read_text(encoding="utf-8")
         users_raw = json.loads(unscramble_string(scrambled))
         # force all usernames to be lowercase (legacy)
         return {key.lower(): value for key, value in users_raw.items()}
@@ -120,13 +119,13 @@ def load_users(path: Union[str, Path]) -> dict[str, str]:
         raise UserTableError(USER_TABLE_ERROR_MESSAGE) from exc
 
 
-def write_users(path: Union[str, Path], users: dict[str, str]) -> None:
+def write_users(path: str | Path, users: dict[str, str]) -> None:
     """Write a user table in the legacy scrambled-JSON format.
 
     The legacy application never writes ``users.txt`` (it is prepared by
     an administrator); this helper exists for tests and admin tooling.
     """
-    Path(path).write_text(scramble_string(json.dumps(users)))
+    Path(path).write_text(scramble_string(json.dumps(users)), encoding="utf-8")
 
 
 class Authenticator:

--- a/src/iv_lab/services/logbook.py
+++ b/src/iv_lab/services/logbook.py
@@ -19,8 +19,8 @@ injectable for tests.
 from __future__ import annotations
 
 import datetime
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional, Union
 
 #: Legacy log file name inside ``sdPath``.
 LOG_FILENAME = "ivlablog.txt"
@@ -34,9 +34,9 @@ class Logbook:
 
     def __init__(
         self,
-        sd_path: Union[str, Path, None],
+        sd_path: str | Path | None,
         *,
-        clock: Optional[Callable[[], datetime.datetime]] = None,
+        clock: Callable[[], datetime.datetime] | None = None,
     ) -> None:
         #: Legacy ``computer.sdPath``; empty/None disables the logbook.
         self.sd_path = str(sd_path) if sd_path is not None else ""
@@ -48,7 +48,7 @@ class Logbook:
         return self.sd_path != ""
 
     @property
-    def log_file_path(self) -> Optional[Path]:
+    def log_file_path(self) -> Path | None:
         """Full path of the log file, or None when disabled."""
         if not self.enabled:
             return None
@@ -71,7 +71,7 @@ class Logbook:
 
         # legacy opened with "w" for a new file and "a" otherwise; both
         # create the file, so append covers both cases
-        with open(log_file, "a") as f:
+        with open(log_file, "a", encoding="utf-8") as f:
             f.write(entry + "\n")
 
     def log_login(self, username: str) -> None:

--- a/tests/test_core_system.py
+++ b/tests/test_core_system.py
@@ -284,7 +284,7 @@ def test_dark_jv_scan_via_core(tmp_path: Path) -> None:
     # dark scan: no metrics computation, so no analysis libraries needed
     system = make_system(tmp_path)
     system.hardware_init()
-    records = Records(system)
+    _records = Records(system)  # kept alive to receive signals during the run
 
     params = {
         "light_int": 0.0,

--- a/tests/test_file_writer_legacy_format.py
+++ b/tests/test_file_writer_legacy_format.py
@@ -289,3 +289,33 @@ def test_data_rows_parse_as_numbers(tmp_path: Path) -> None:
     for line in lines[n_header:]:
         values = [float(x) for x in line.split(",")]
         assert len(values) == 3
+
+
+def test_data_file_is_written_as_utf8(tmp_path: Path) -> None:
+    # A non-ASCII header value (here in the light-source name) must be encoded
+    # as UTF-8, not the platform default (cp1252 on Windows). The micro sign
+    # U+00B5 is b"\xc2\xb5" in UTF-8 but b"\xb5" in cp1252, so checking the raw
+    # bytes catches a regression to the locale encoding on any platform.
+    writer = make_writer(tmp_path, lamp_display_name="µ-cell lamp")
+
+    csv_path, _ = writer.save(iv_result(), "felix")
+    raw = csv_path.read_bytes()
+
+    # UTF-8 encodes µ (U+00B5) as the two bytes 0xC2 0xB5; cp1252 would emit a
+    # lone 0xB5, which is an invalid UTF-8 start byte. So the presence of the
+    # two-byte sequence AND a clean UTF-8 decode together prove the codec.
+    assert b"\xc2\xb5-cell lamp" in raw
+    assert "Light Source,µ-cell lamp" in raw.decode("utf-8")
+
+
+def test_scrambled_duplicate_is_written_as_utf8(tmp_path: Path) -> None:
+    # The sdPath copy holds scrambled (hex) content + a hex filename, so its
+    # bytes are ASCII; the regression guard is simply that it is created and
+    # readable as UTF-8 without raising.
+    writer = make_writer(tmp_path)
+    writer.save(iv_result(), "felix")
+
+    sd_files = list(Path(writer.context.sd_path).glob("*"))
+    assert sd_files, "expected a scrambled duplicate file under sd_path"
+    # readable as UTF-8 (would raise if written/read with a mismatched codec)
+    sd_files[0].read_text(encoding="utf-8")

--- a/tests/test_gui_components.py
+++ b/tests/test_gui_components.py
@@ -1,6 +1,5 @@
 """Headless tests for the GUI building blocks (offscreen platform)."""
 
-import pytest
 
 from iv_lab.data.results import IVResults
 from iv_lab.gui.dialogs.logoff_dialog import LogOffDialog
@@ -13,7 +12,6 @@ from iv_lab.gui.panels.plot_panel import (
     PANEL_MPP,
     PlotPanel,
 )
-
 
 # --- light panel ---
 

--- a/tests/test_iv_curve_emulated.py
+++ b/tests/test_iv_curve_emulated.py
@@ -98,8 +98,8 @@ def test_emulated_iv_scan_returns_result_with_plausible_data() -> None:
     assert result.current[-1] > 0
     # metrics from the injected analysis function, PCE per legacy formula
     assert result.Voc == pytest.approx(0.55)
-    assert result.FF == pytest.approx(0.726)
-    assert result.PCE == pytest.approx(8.46)
+    assert pytest.approx(0.726) == result.FF
+    assert pytest.approx(8.46) == result.PCE
     # parameters recorded with legacy key spelling
     assert result.cell_name == "test cell"
     assert result.start_V == pytest.approx(0.0)

--- a/tests/test_lamp_real_drivers.py
+++ b/tests/test_lamp_real_drivers.py
@@ -725,7 +725,6 @@ def test_verasol_light_on_below_minimum_raises(fake_verasol_lib) -> None:
 def test_verasol_amplitude_mismatch_raises(fake_verasol_lib) -> None:
     # Fake an instrument that reports a different amplitude than requested.
     fake_verasol_lib._amplitude = 0.5  # will be reported after set_amplitude
-    original_set = FakeVeraSol.set_amplitude
 
     def _bad_set(self, suns):
         pass  # don't update _amplitude — simulate mismatch

--- a/tests/test_measurement_workers.py
+++ b/tests/test_measurement_workers.py
@@ -34,8 +34,8 @@ from iv_lab.measurements.workers import (
     ConstantCurrentWorker,
     ConstantVoltageWorker,
     IVCurveWorker,
-    MPPTrackingWorker,
     MeasurementWorker,
+    MPPTrackingWorker,
 )
 
 # QtCore needs an application object; create one for the whole module

--- a/tests/test_smu_emulation.py
+++ b/tests/test_smu_emulation.py
@@ -128,10 +128,10 @@ def test_emulated_iv_curve_is_diode_shaped() -> None:
     # photocurrent at short circuit: i(0) ~ Isc = -full_sun_reference_current
     assert currents[0] == pytest.approx(-0.004, rel=0.02)
     # monotonically increasing diode curve
-    assert all(b > a for a, b in zip(currents, currents[1:]))
+    assert all(b > a for a, b in zip(currents, currents[1:], strict=False))
     # crosses zero at the emulated Voc
     assert min(currents) < 0 < max(currents)
-    zero_crossing = next(v for v, i in zip(voltages, currents) if i >= 0)
+    zero_crossing = next(v for v, i in zip(voltages, currents, strict=False) if i >= 0)
     assert zero_crossing == pytest.approx(EMULATED_VOC, abs=0.05)
 
 

--- a/tests/test_time_dependent_protocols.py
+++ b/tests/test_time_dependent_protocols.py
@@ -86,7 +86,7 @@ def test_constant_voltage_returns_plausible_currents() -> None:
     assert result.current[0] == pytest.approx(-0.00397, rel=0.05)
     # time axis starts at zero and increases
     assert result.time[0] == pytest.approx(0.0, abs=0.01)
-    assert all(b > a for a, b in zip(result.time, result.time[1:]))
+    assert all(b > a for a, b in zip(result.time, result.time[1:], strict=False))
     assert result.set_voltage == 0.2
 
 


### PR DESCRIPTION
Code-quality batch from the codebase review. **No behavior change** to measurements; full suite **401 passing**, ruff clean.

## UTF-8 file I/O (correctness)
All text file writing/reading now passes `encoding="utf-8"` — data files, the scrambled `sdPath` duplicate, the per-user GUI config, `users.txt`, and the logbook. These previously used the platform default (cp1252 on Windows), which could corrupt non-ASCII content and diverge from the UTF-8 settings files. Two regression tests assert the data file is genuinely written as UTF-8.

## Linting (ruff)
- New `[tool.ruff]` config (`E/W/F/I/UP/B/C4/SIM`); bundled verbatim legacy libraries (`_keithley26xx_lib.py`, `_verasol_lib.py`, `jv_analysis.py`) and `docs/` are excluded. `ruff` added to the `dev` extra.
- Autofixes: PEP 604 annotations (`Optional`/`Union` → `X | None`), modern typing imports, f-strings, import sorting, unused-import removal.
- Manual fixes: `try/except/pass` → `contextlib.suppress`; `if/else` → ternary; explicit `zip(strict=False)`; bound a loop variable in a calibration closure (B023); removed dead test assignments.

## Packaging
- Conservative lower bounds on core deps for reproducibility (floors well below current releases).
- New `hardware` optional-dependency group (`pyvisa`, `pyvisa-py`, `pymeasure`, `pytrinamic`) → `pip install iv_lab[hardware]`. These stay lazily imported, so emulation needs none of them.

## Deliberately out of scope (follow-ups)
- Auth security notes (reversible obfuscation, generic password) — preserved legacy format per CLAUDE.md.
- `ruff format` (would be a large, separate reformat).
- Broad-`except` review beyond the contextlib conversions, and panel encapsulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)