### PR TITLE
fix: run hardware initialization off the GUI thread

### DIFF
--- a/src/iv_lab/core/system.py
+++ b/src/iv_lab/core/system.py
@@ -33,7 +33,7 @@ import datetime
 from dataclasses import dataclass
 from pathlib import Path
 
-from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtCore import QObject, QThread, Signal, Slot
 
 from iv_lab.config import SystemSettings, save_settings
 from iv_lab.data import FileWriter, SystemContext
@@ -127,6 +127,30 @@ MEASUREMENTS = {
 }
 
 
+class _HardwareInitWorker(QObject):
+    """Runs ``IVLabSystem.hardware_init()`` on a worker thread.
+
+    Hardware connection involves blocking VISA calls that can take seconds
+    (or hang on a mis-wired instrument); running them here keeps the GUI
+    responsive. ``hardware_init`` reports through the system's own signals,
+    so this worker only needs to signal when it is done (so the thread can
+    quit). ``hardware_init`` handles its own errors and never raises.
+    """
+
+    done = Signal()
+
+    def __init__(self, system: IVLabSystem) -> None:
+        super().__init__()
+        self._system = system
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            self._system.hardware_init()
+        finally:
+            self.done.emit()
+
+
 class IVLabSystem(QObject):
     """Coordinates hardware, measurements, data, and services."""
 
@@ -211,6 +235,10 @@ class IVLabSystem(QObject):
         self._thread: QThread | None = None
         self._running = False
 
+        # background hardware-initialization thread (keeps the GUI responsive)
+        self._init_worker: _HardwareInitWorker | None = None
+        self._init_thread: QThread | None = None
+
     # --- hardware (legacy hardware_init) ---
 
     def hardware_init(self) -> bool:
@@ -260,6 +288,40 @@ class IVLabSystem(QObject):
         self.status_message.emit("Hardware initialized")
         self.hardware_ready.emit(True)
         return True
+
+    def start_hardware_init(self) -> None:
+        """Connect hardware without blocking the caller.
+
+        In threaded mode (the GUI) the connection runs on a worker thread so
+        a slow or hanging instrument cannot freeze the UI; progress and the
+        final ``hardware_ready`` are reported through the usual signals. In
+        non-threaded mode (tests/scripting) it runs synchronously. A second
+        call while an initialization is already running is ignored.
+        """
+        if not self.threaded:
+            self.hardware_init()
+            return
+        if self._init_thread is not None and self._init_thread.isRunning():
+            return
+
+        worker = _HardwareInitWorker(self)
+        thread = QThread(self)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.done.connect(thread.quit)
+        thread.finished.connect(self._cleanup_init_thread)
+        self._init_worker = worker
+        self._init_thread = thread
+        thread.start()
+
+    def _cleanup_init_thread(self) -> None:
+        # runs in the main thread after the init thread finished; drop the
+        # worker reference and reclaim the thread object (mirrors
+        # _cleanup_worker)
+        self._init_worker = None
+        if self._init_thread is not None:
+            self._init_thread.deleteLater()
+            self._init_thread = None
 
     def turn_off(self) -> None:
         """Bring the hardware into a safe state.

--- a/src/iv_lab/gui/main_window.py
+++ b/src/iv_lab/gui/main_window.py
@@ -193,7 +193,7 @@ class MainWindow(QMainWindow):
         system.data_updated.connect(self.plot_panel.update_live_data)
         system.measurement_finished.connect(self._on_measurement_finished)
         system.calibration_ready.connect(self._on_calibration_ready)
-        system.hardware_ready.connect(self._set_hardware_active)
+        system.hardware_ready.connect(self._on_hardware_ready)
         system.user_logged_in.connect(self._on_logged_in)
         system.user_logged_out.connect(self._on_logged_out)
 
@@ -308,7 +308,16 @@ class MainWindow(QMainWindow):
     # --- hardware (legacy initializeHardware / setHardwareActive) ---
 
     def _initialize_hardware(self) -> None:
-        self.system.hardware_init()
+        # disable the button so the connection cannot be re-triggered while it
+        # runs; the work happens off the GUI thread so the window stays
+        # responsive (re-enabled in _on_hardware_ready).
+        self.button_initialize.setEnabled(False)
+        self.system.start_hardware_init()
+
+    def _on_hardware_ready(self, active: bool) -> None:
+        # re-enable so the user can retry after a failed initialization
+        self.button_initialize.setEnabled(True)
+        self._set_hardware_active(active)
 
     def _set_hardware_active(self, active: bool) -> None:
         self.light_panel.setEnabled(active)

--- a/tests/test_core_system.py
+++ b/tests/test_core_system.py
@@ -1,6 +1,8 @@
 """Tests for the core system orchestrator (headless, emulated hardware)."""
 
 import json
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -180,6 +182,50 @@ def test_hardware_init_failure_emits_legacy_message(tmp_path: Path) -> None:
     assert records.hardware == [False]
     assert "Error initializing keithley sourcemeter" in records.errors[0]
     assert "no VISA resource" in records.errors[0]
+
+
+def test_start_hardware_init_synchronous_when_not_threaded(tmp_path: Path) -> None:
+    system = make_system(tmp_path)  # make_system defaults to threaded=False
+    records = Records(system)
+
+    system.start_hardware_init()
+
+    # ran inline: connected and reported without spawning a thread
+    assert system.smu.is_connected()
+    assert system.lamp.is_connected()
+    assert records.hardware == [True]
+    assert system._init_thread is None
+
+
+def test_start_hardware_init_runs_off_the_main_thread(tmp_path: Path) -> None:
+    system = make_system(tmp_path, threaded=True)
+    records = Records(system)
+
+    main_ident = threading.get_ident()
+    ran_on: dict = {}
+    original = system.hardware_init
+
+    def spy() -> bool:
+        ran_on["ident"] = threading.get_ident()
+        return original()
+
+    system.hardware_init = spy
+
+    system.start_hardware_init()
+    # control returned immediately; the work happens on a worker thread
+    wait_for(system.hardware_ready)
+
+    assert records.hardware == [True]
+    assert system.smu.is_connected()
+    # the blocking connection ran off the GUI/main thread, so it could not
+    # have frozen the UI
+    assert ran_on["ident"] != main_ident
+
+    # let the init thread wind down and clean up before the next test
+    deadline = time.monotonic() + 5.0
+    while system._init_thread is not None and time.monotonic() < deadline:
+        QCoreApplication.processEvents()
+    assert system._init_thread is None
 
 
 # --- login / logout ---


### PR DESCRIPTION
## Problem
Pressing **Initialize** called `system.hardware_init()` synchronously on the GUI thread, so a slow or hanging instrument froze the entire window. This bit us when swapping in a different Keithley 2400 whose RS-232 front-panel settings didn't match — a serial write blocked (flow control), and the app hung permanently rather than erroring.

## Fix
Initialization now runs on a `QThread`, mirroring the existing measurement-worker pattern:

- New `_HardwareInitWorker` runs `hardware_init()` off-thread; progress and the final `hardware_ready(bool)` still flow through the system's existing signals (queued to the GUI thread).
- `IVLabSystem.start_hardware_init()` dispatches to the worker thread when `threaded`, or runs synchronously otherwise (tests/scripting); a second call while one is in flight is ignored.
- The GUI disables the **Initialize** button while connecting and re-enables it on `hardware_ready`, so a failed attempt is retryable. The window stays responsive throughout.

`hardware_init()` itself is unchanged (still synchronous, still handles its own errors), so existing callers/tests are unaffected.

## Tests
- `start_hardware_init` runs synchronously when not threaded.
- `start_hardware_init` runs off the main thread when threaded (verified via thread id) and cleans up its thread.
- Full suite: **403 passing**, ruff clean.

## Follow-up (not in this PR)
A serial `write_timeout` would additionally turn a flow-control-blocked write into an error instead of a (now non-freezing, but still stuck) background thread. Worth a small separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)