### PR TITLE
docs: clarify the serial timeout bounds writes, not just reads

### DIFF
--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -113,7 +113,13 @@ class Keithley2400FamilySMU(BaseSMU):
         termination characters or every read hangs until the VISA timeout
         (GPIB/USB signal end-of-message on the bus, so they need none). The
         defaults come from ``_SERIAL_DEFAULTS`` and can be overridden per
-        machine via the settings file. A read ``timeout`` is always applied.
+        machine via the settings file.
+
+        A ``timeout`` is always applied. On serial it bounds writes as well
+        as reads -- pyvisa-py maps the VISA timeout onto pyserial's
+        ``write_timeout`` and NI-VISA uses a single timeout for both -- so a
+        write blocked by an RS-232 flow-control mismatch fails after the
+        timeout instead of hanging the connection indefinitely.
         """
         kwargs: dict = {}
         timeout = self.settings.timeout_ms


### PR DESCRIPTION
Follow-up from PR #6's note about adding a serial `write_timeout`.

## Finding
Investigating showed the write timeout is **already handled** by the existing `timeout`:
- pyvisa-py's serial session sets pyserial's `write_timeout` equal to the VISA timeout, with a ms→s conversion in the base session.
- NI-VISA uses a single timeout for both reads and writes.
- The driver already passes `timeout` for `ASRL` addresses (unit-tested as `kwargs["timeout"] == 5000.0`).

So a serial write blocked by an RS-232 flow-control mismatch already fails after the timeout rather than hanging — in both backends. pyvisa's high-level API doesn't expose a separate `write_timeout` to set anyway.

## Change
Doc-only: the `_connection_kwargs` docstring said only a "read" timeout was applied. Corrected it to document that the timeout bounds writes too (and why), so this safety property isn't re-derived later. No behavior change; ruff clean; Keithley tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)