### PR TITLE
fix: Keithley 2400 current compliance clamped to ~105 µA

### DIFF
--- a/config/examples/verasol_glovebox.toml
+++ b/config/examples/verasol_glovebox.toml
@@ -56,7 +56,11 @@ visa_library = "@py"                  # pyvisa-py backend (no NI-VISA required)
 #   visa_library = "C:\\Windows\\SysWOW64\\visa32.dll"
 emulate = false
 referenceDiodeSenseMode = "2wire"     # "2wire" or "4 wire"
-autorange = true
+# Use a FIXED current range on the Keithley 2400: with autorange the 2400
+# starts on its lowest (100 uA) range and the source current compliance is
+# clamped to ~105 uA, because the measurement cannot range up while the
+# current is being clamped. false fixes the range to the compliance (Imax).
+autorange = false
 useReferenceDiode = false             # glovebox typically has no reference diode
 
 # --- RS-232 serial parameters (only used for ASRL addresses) ---

--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -297,7 +297,11 @@ class Keithley2400FamilySMU(BaseSMU):
         # legacy passed its whole range/autorange dicts here, which are
         # always truthy: the effective call is nplc=1 with autoranging on.
         # pymeasure 0.16 deprecated the measure_voltage(nplc, range, auto)
-        # config form; configure the equivalent explicitly instead.
+        # config form; replicate exactly what it wrote, including selecting
+        # the voltage sense function. Without ":SENS:FUNC 'VOLT'" the active
+        # measurement function (and range) is wrong, which clamps the source
+        # compliance to the default range.
+        self.smu.write(":SENS:FUNC 'VOLT'")
         self.smu.voltage_nplc = 1
         self.smu.voltage_range_auto_enabled = True
         if state.output:
@@ -315,7 +319,11 @@ class Keithley2400FamilySMU(BaseSMU):
         self.smu.source_mode = "voltage"
         # see set_mode_current_source: effectively nplc=1, autorange on.
         # pymeasure 0.16 deprecated the measure_current(nplc, range, auto)
-        # config form; configure the equivalent explicitly instead.
+        # config form; replicate exactly what it wrote, including selecting
+        # the current sense function. Without ":SENS:FUNC 'CURR'" the current
+        # measurement range stays on its 100 uA default and clamps the source
+        # current compliance to ~105 uA (105 % of range).
+        self.smu.write(":SENS:FUNC 'CURR'")
         self.smu.current_nplc = 1
         self.smu.current_range_auto_enabled = True
         if state.output:

--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -294,16 +294,20 @@ class Keithley2400FamilySMU(BaseSMU):
         if state.output:
             self.smu.disable_source()
         self.smu.source_mode = "current"
-        # legacy passed its whole range/autorange dicts here, which are
-        # always truthy: the effective call is nplc=1 with autoranging on.
-        # pymeasure 0.16 deprecated the measure_voltage(nplc, range, auto)
-        # config form; replicate exactly what it wrote, including selecting
-        # the voltage sense function. Without ":SENS:FUNC 'VOLT'" the active
-        # measurement function (and range) is wrong, which clamps the source
-        # compliance to the default range.
+        # Replicate the legacy measure_voltage(nplc=1, range, auto) call that
+        # pymeasure 0.16 deprecated: select the voltage sense function, set
+        # nplc=1, and configure the range. The legacy code always passed a
+        # truthy auto-range flag, but that re-enables autorange even after
+        # setup_*_output deliberately fixed the range — and on the 2400 an
+        # autoranged measurement clamps the source compliance to whatever
+        # range it auto-selects (the 100 uA default at low signal). Honor the
+        # channel's actual autorange state instead: fixed range when off.
         self.smu.write(":SENS:FUNC 'VOLT'")
         self.smu.voltage_nplc = 1
-        self.smu.voltage_range_auto_enabled = True
+        if state.volt_autorange:
+            self.smu.voltage_range_auto_enabled = True
+        else:
+            self.smu.voltage_range = state.v_range
         if state.output:
             self.smu.enable_source()
         state.source_mode = "current"
@@ -317,15 +321,17 @@ class Keithley2400FamilySMU(BaseSMU):
         if state.output:
             self.smu.disable_source()
         self.smu.source_mode = "voltage"
-        # see set_mode_current_source: effectively nplc=1, autorange on.
-        # pymeasure 0.16 deprecated the measure_current(nplc, range, auto)
-        # config form; replicate exactly what it wrote, including selecting
-        # the current sense function. Without ":SENS:FUNC 'CURR'" the current
-        # measurement range stays on its 100 uA default and clamps the source
-        # current compliance to ~105 uA (105 % of range).
+        # see set_mode_current_source: select the current sense function, set
+        # nplc=1, and honor the channel's autorange state. Re-enabling
+        # autorange here (the legacy behavior) drops the current range back to
+        # its 100 uA default, which clamps the source current compliance to
+        # ~105 uA -- so when autorange is off, apply the fixed range instead.
         self.smu.write(":SENS:FUNC 'CURR'")
         self.smu.current_nplc = 1
-        self.smu.current_range_auto_enabled = True
+        if state.curr_autorange:
+            self.smu.current_range_auto_enabled = True
+        else:
+            self.smu.current_range = state.i_range
         if state.output:
             self.smu.enable_source()
         state.source_mode = "voltage"

--- a/tests/test_smu_keithley_2400.py
+++ b/tests/test_smu_keithley_2400.py
@@ -318,7 +318,20 @@ def test_setup_voltage_output_fixed_range_when_autorange_off(fake_pymeasure) -> 
 
     assert ":CURR:RANG:AUTO OFF" in fake.writes()
     assert ":CURR:RANG:AUTO ON" not in fake.writes()
-    assert fake.sets("current_range") == [0.02]
+    assert 0.02 in fake.sets("current_range")
+    # the mode setup must NOT re-enable autorange (doing so drops the current
+    # range to its 100 uA default and clamps the compliance to ~105 uA)
+    assert fake.sets("current_range_auto_enabled") == []
+
+
+def test_setup_current_output_fixed_range_when_autorange_off(fake_pymeasure) -> None:
+    smu, fake = connected_smu(fake_pymeasure, autorange=False)
+
+    smu.setup_current_output(SMUChannel.CELL, 1.0)
+
+    assert 1.0 in fake.sets("voltage_range")
+    # likewise the voltage measurement autorange must not be re-enabled
+    assert fake.sets("voltage_range_auto_enabled") == []
 
 
 def test_setup_current_output_selects_voltage_sense_function(fake_pymeasure) -> None:

--- a/tests/test_smu_keithley_2400.py
+++ b/tests/test_smu_keithley_2400.py
@@ -302,6 +302,9 @@ def test_setup_voltage_output_replicates_legacy_sequence(fake_pymeasure) -> None
     # voltage source mode with current measurement configured (nplc=1, autorange);
     # pymeasure 0.16 replaced measure_current(nplc, range, auto) with explicit props
     assert fake.sets("source_mode") == ["voltage"]
+    # the current sense function must be selected, or the measurement range
+    # stays on its 100 uA default and clamps the source compliance to ~105 uA
+    assert ":SENS:FUNC 'CURR'" in fake.writes()
     assert 1 in fake.sets("current_nplc")
     assert fake.sets("current_range_auto_enabled") == [True]
     # current display (legacy SYST:KEY 22, non-2450 only)
@@ -316,6 +319,20 @@ def test_setup_voltage_output_fixed_range_when_autorange_off(fake_pymeasure) -> 
     assert ":CURR:RANG:AUTO OFF" in fake.writes()
     assert ":CURR:RANG:AUTO ON" not in fake.writes()
     assert fake.sets("current_range") == [0.02]
+
+
+def test_setup_current_output_selects_voltage_sense_function(fake_pymeasure) -> None:
+    # current source mode (e.g. the Voc / reference-diode setup) measures
+    # voltage; the voltage sense function must be selected so the measurement
+    # range and the source compliance are correct
+    smu, fake = connected_smu(fake_pymeasure)
+
+    smu.setup_current_output(SMUChannel.CELL, 1.0)
+
+    assert fake.sets("source_mode") == ["current"]
+    assert ":SENS:FUNC 'VOLT'" in fake.writes()
+    assert 1 in fake.sets("voltage_nplc")
+    assert fake.sets("voltage_range_auto_enabled") == [True]
 
 
 def test_set_voltage_and_measure_current(fake_pymeasure) -> None:


### PR DESCRIPTION
## Symptom
On the serial Keithley 2400, **Calibrate Reference Diode** (and every measurement) clamps the current to **~105 µA** — the front panel shows compliance = 105 µA regardless of the configured `Imax` / `referenceDiodeImax`.

## Root cause (confirmed on the instrument)
A probe showed `:SENS:CURR:PROT?` correctly returned the requested 10 mA, but `:SENS:CURR:RANG?` was stuck at `1.05E-04` (the 100 µA range). On the 2400 the **effective** current limit is the measurement-range maximum, so the source clamps at 105 µA. Trying to raise the range above the compliance raises error **824 "Cannot exceed compliance range"**, and with autorange enabled the range can't climb because the current is already clamped (a deadlock).

The driver bug: `set_mode_voltage_source` / `set_mode_current_source` unconditionally set `current_range_auto_enabled = True` (and voltage). This **re-enables autorange even when `setup_*_output` deliberately fixed the range** for `autorange = false`, dropping the range back to 100 µA. The legacy code had the same latent bug (it passed its whole autorange *dict*, always truthy); this old 2400 firmware exposes it.

## Fix
- `set_mode_*` now honors the channel's actual autorange state: when autorange is off it applies the **fixed range** (= compliance / `Imax`) instead of re-enabling autorange.
- Also restored the `:SENS:FUNC 'CURR'` / `'VOLT'` selection that the deprecated pymeasure config calls used to send (dropped in the 0.16 migration).
- Set `autorange = false` in the glovebox example config — the 2400 needs a fixed current range.

## Tests
- `setup_voltage_output` / `setup_current_output` with autorange off assert the mode setup does **not** re-enable autorange and applies the fixed range.
- Sense-function selection is asserted for both source modes.
- Full suite: **405 passing**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)