### PR TITLE
feat: scope the Keithley 2400 fixed-range workaround to a specific serial

### DIFF
--- a/config/examples/verasol_glovebox.toml
+++ b/config/examples/verasol_glovebox.toml
@@ -50,17 +50,18 @@ visa_address = "USB0::0x1FDE::0x000A::71201042::INSTR"
 [SMU]
 brand = "Keithley"
 model = "2400"                        # 2400 | 2401 | 2450 — pymeasure driver
+# serial_number: *IDN? field 3. Optional. A few specific 2400 units have
+# unreliable measurement autorange that clamps the source compliance to
+# ~105 uA; the driver detects those by serial and uses a fixed range instead.
+# Set this to your instrument's serial only if it is one of them.
+serial_number = "0683014"
 visa_address = "ASRL4::INSTR"         # serial port COM4 (pyvisa ASRL format)
 visa_library = "@py"                  # pyvisa-py backend (no NI-VISA required)
 # If you have NI-VISA installed, use the path to visa32.dll instead:
 #   visa_library = "C:\\Windows\\SysWOW64\\visa32.dll"
 emulate = false
 referenceDiodeSenseMode = "2wire"     # "2wire" or "4 wire"
-# Use a FIXED current range on the Keithley 2400: with autorange the 2400
-# starts on its lowest (100 uA) range and the source current compliance is
-# clamped to ~105 uA, because the measurement cannot range up while the
-# current is being clamped. false fixes the range to the compliance (Imax).
-autorange = false
+autorange = true
 useReferenceDiode = false             # glovebox typically has no reference diode
 
 # --- RS-232 serial parameters (only used for ASRL addresses) ---

--- a/src/iv_lab/config/settings.py
+++ b/src/iv_lab/config/settings.py
@@ -104,6 +104,11 @@ class SMUSettings(LegacyCompatibleModel):
     autorange: bool = True
     measSpeed: str = "normal"
     useReferenceDiode: bool = True
+    #: Instrument serial number (the 3rd field of ``*IDN?``).  Optional; used
+    #: to apply per-unit workarounds — e.g. a specific Keithley 2400 whose
+    #: current autorange is unreliable falls back to a fixed range (see
+    #: ``keithley_2400.py``).
+    serial_number: str | None = None
     #: Serial (RS-232 / ``ASRL``) connection parameters.  Ignored for GPIB/USB
     #: addresses, where termination is handled by the bus (EOI).  For a serial
     #: Keithley these must match the instrument's front-panel RS-232 settings,

--- a/src/iv_lab/hardware/smu/drivers/keithley_2400.py
+++ b/src/iv_lab/hardware/smu/drivers/keithley_2400.py
@@ -54,6 +54,14 @@ _SERIAL_DEFAULTS = {
 #: short timeout turns a slow-but-valid read into a spurious VI_ERROR_TMO.
 _DEFAULT_TIMEOUT_MS = 5000.0
 
+#: Serial numbers of individual Keithley 2400 units whose current/voltage
+#: measurement autorange is unreliable: at low signal the range sits on its
+#: lowest setting and clamps the source compliance (e.g. ~105 uA on the 100 uA
+#: range), and it cannot range up because the signal is already clamped. These
+#: units fall back to a fixed measurement range (= the compliance limit). All
+#: other 2400s keep normal autorange. Matched against ``SMUSettings.serial_number``.
+_FIXED_RANGE_SERIALS = frozenset({"0683014"})
+
 
 @dataclass
 class _ChannelState:
@@ -89,6 +97,12 @@ class Keithley2400FamilySMU(BaseSMU):
         self.autorange = settings.autorange
         self.meas_speed = settings.measSpeed
         self.use_reference_diode = settings.useReferenceDiode
+        #: Per-unit workaround: this specific instrument has unreliable
+        #: measurement autorange, so it uses a fixed range (= compliance).
+        #: Other 2400s keep normal autorange behavior.
+        self._fixed_range_workaround = (
+            (settings.serial_number or "").strip() in _FIXED_RANGE_SERIALS
+        )
         #: Sense mode of the cell channel (legacy ``senseModeA``; the legacy
         #: code never overrides its '2 wire' default from the settings file).
         self.sense_mode_a: str = "2 wire"
@@ -294,20 +308,17 @@ class Keithley2400FamilySMU(BaseSMU):
         if state.output:
             self.smu.disable_source()
         self.smu.source_mode = "current"
-        # Replicate the legacy measure_voltage(nplc=1, range, auto) call that
-        # pymeasure 0.16 deprecated: select the voltage sense function, set
-        # nplc=1, and configure the range. The legacy code always passed a
-        # truthy auto-range flag, but that re-enables autorange even after
-        # setup_*_output deliberately fixed the range — and on the 2400 an
-        # autoranged measurement clamps the source compliance to whatever
-        # range it auto-selects (the 100 uA default at low signal). Honor the
-        # channel's actual autorange state instead: fixed range when off.
+        # Select the voltage sense function and nplc=1, replicating the legacy
+        # measure_voltage(nplc, range, auto) call that pymeasure 0.16 deprecated.
+        # For most 2400s the range autoranges (legacy behavior). On the specific
+        # unit(s) flagged by serial number, autorange is unreliable and clamps
+        # the source compliance, so use a fixed range = the compliance limit.
         self.smu.write(":SENS:FUNC 'VOLT'")
         self.smu.voltage_nplc = 1
-        if state.volt_autorange:
-            self.smu.voltage_range_auto_enabled = True
+        if self._fixed_range_workaround:
+            self.smu.voltage_range = state.v_limit
         else:
-            self.smu.voltage_range = state.v_range
+            self.smu.voltage_range_auto_enabled = True
         if state.output:
             self.smu.enable_source()
         state.source_mode = "current"
@@ -321,17 +332,17 @@ class Keithley2400FamilySMU(BaseSMU):
         if state.output:
             self.smu.disable_source()
         self.smu.source_mode = "voltage"
-        # see set_mode_current_source: select the current sense function, set
-        # nplc=1, and honor the channel's autorange state. Re-enabling
-        # autorange here (the legacy behavior) drops the current range back to
-        # its 100 uA default, which clamps the source current compliance to
-        # ~105 uA -- so when autorange is off, apply the fixed range instead.
+        # see set_mode_current_source: select the current sense function and
+        # nplc=1. Most 2400s autorange the current measurement (legacy). The
+        # serial-flagged unit instead uses a fixed range = the compliance
+        # limit, because its autorange clamps the source compliance to ~105 uA
+        # (the 100 uA range) and cannot range up.
         self.smu.write(":SENS:FUNC 'CURR'")
         self.smu.current_nplc = 1
-        if state.curr_autorange:
-            self.smu.current_range_auto_enabled = True
+        if self._fixed_range_workaround:
+            self.smu.current_range = state.i_limit
         else:
-            self.smu.current_range = state.i_range
+            self.smu.current_range_auto_enabled = True
         if state.output:
             self.smu.enable_source()
         state.source_mode = "voltage"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,6 +74,17 @@ def test_smu_legacy_defaults(tmp_path: Path) -> None:
     assert settings.SMU.autorange is True
     assert settings.SMU.measSpeed == "normal"
     assert settings.SMU.useReferenceDiode is True
+    # optional per-unit serial number is absent by default
+    assert settings.SMU.serial_number is None
+
+
+def test_smu_serial_number_is_parsed(tmp_path: Path) -> None:
+    data = json.loads(json.dumps(MINIMAL_SETTINGS))
+    data["SMU"]["serial_number"] = "0683014"
+
+    settings = load_settings(write_settings(tmp_path, data))
+
+    assert settings.SMU.serial_number == "0683014"
 
 
 def test_extra_legacy_fields_are_allowed(tmp_path: Path) -> None:

--- a/tests/test_smu_keithley_2400.py
+++ b/tests/test_smu_keithley_2400.py
@@ -318,20 +318,7 @@ def test_setup_voltage_output_fixed_range_when_autorange_off(fake_pymeasure) -> 
 
     assert ":CURR:RANG:AUTO OFF" in fake.writes()
     assert ":CURR:RANG:AUTO ON" not in fake.writes()
-    assert 0.02 in fake.sets("current_range")
-    # the mode setup must NOT re-enable autorange (doing so drops the current
-    # range to its 100 uA default and clamps the compliance to ~105 uA)
-    assert fake.sets("current_range_auto_enabled") == []
-
-
-def test_setup_current_output_fixed_range_when_autorange_off(fake_pymeasure) -> None:
-    smu, fake = connected_smu(fake_pymeasure, autorange=False)
-
-    smu.setup_current_output(SMUChannel.CELL, 1.0)
-
-    assert 1.0 in fake.sets("voltage_range")
-    # likewise the voltage measurement autorange must not be re-enabled
-    assert fake.sets("voltage_range_auto_enabled") == []
+    assert fake.sets("current_range") == [0.02]
 
 
 def test_setup_current_output_selects_voltage_sense_function(fake_pymeasure) -> None:
@@ -345,7 +332,42 @@ def test_setup_current_output_selects_voltage_sense_function(fake_pymeasure) -> 
     assert fake.sets("source_mode") == ["current"]
     assert ":SENS:FUNC 'VOLT'" in fake.writes()
     assert 1 in fake.sets("voltage_nplc")
+    # a normal 2400 (no serial flag) autoranges
     assert fake.sets("voltage_range_auto_enabled") == [True]
+
+
+# --- per-unit fixed-range workaround (serial-flagged 2400) ---
+
+
+def test_flagged_serial_uses_fixed_current_range(fake_pymeasure) -> None:
+    # the specific unit with unreliable autorange uses a fixed current range
+    # (= the compliance limit) instead of re-enabling autorange
+    smu, fake = connected_smu(fake_pymeasure, serial_number="0683014")
+
+    smu.setup_voltage_output(SMUChannel.CELL, 0.02)
+
+    assert smu._fixed_range_workaround is True
+    assert fake.sets("current_range") == [0.02]          # = compliance / Imax
+    assert fake.sets("current_range_auto_enabled") == []  # autorange NOT used
+
+
+def test_flagged_serial_uses_fixed_voltage_range(fake_pymeasure) -> None:
+    smu, fake = connected_smu(fake_pymeasure, serial_number="0683014")
+
+    smu.setup_current_output(SMUChannel.CELL, 1.0)
+
+    assert fake.sets("voltage_range") == [1.0]            # = voltage compliance
+    assert fake.sets("voltage_range_auto_enabled") == []
+
+
+def test_unflagged_serial_keeps_autorange(fake_pymeasure) -> None:
+    # any other serial number is unaffected: normal autorange
+    smu, fake = connected_smu(fake_pymeasure, serial_number="9999999")
+
+    smu.setup_voltage_output(SMUChannel.CELL, 0.02)
+
+    assert smu._fixed_range_workaround is False
+    assert fake.sets("current_range_auto_enabled") == [True]
 
 
 def test_set_voltage_and_measure_current(fake_pymeasure) -> None:


### PR DESCRIPTION
Follow-up to #8. The ~105 µA compliance clamp only affects one old 2400 unit (serial **0683014**, 1997 firmware) — other 2400s autorange fine. This scopes the fixed-range workaround to that unit instead of applying it to every 2400.

## Changes
- `SMUSettings` gains an optional **`serial_number`** field (`*IDN?` field 3).
- The driver keeps a set of serials with unreliable autorange (`_FIXED_RANGE_SERIALS = {"0683014"}`). A matching unit uses a **fixed measurement range = the compliance limit** in `set_mode_voltage_source` / `set_mode_current_source`; **every other 2400 keeps normal autorange** (legacy behavior, unchanged).
- The glovebox config records `serial_number = "0683014"` and returns `autorange` to `true` — the serial now drives the workaround, so no per-machine autorange change is needed.

## Behavior matrix
| Unit | Result |
|---|---|
| serial in `_FIXED_RANGE_SERIALS` | fixed current/voltage range (= compliance) |
| any other / no serial | normal autorange (unchanged) |

## Tests
- Flagged serial → fixed range; unflagged serial → autorange; `serial_number` parsing.
- Full suite: **408 passing**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)