### PR TITLE
feat: config-driven calibration diode dropdown

### DIFF
--- a/config/examples/bcl.toml
+++ b/config/examples/bcl.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "Trinamic"
 model = "TMCM-1260"

--- a/config/examples/bcl_old_iv.toml
+++ b/config/examples/bcl_old_iv.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "Trinamic"
 model = "TMCM-3110"                  # 3-axis controller; only axis 1 used for filter wheel

--- a/config/examples/dell.toml
+++ b/config/examples/dell.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "manual"
 model = "manual"

--- a/config/examples/fte.toml
+++ b/config/examples/fte.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "manual"
 model = "manual"

--- a/config/examples/gmf.toml
+++ b/config/examples/gmf.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.008        # larger steps than default
 MPPVoltageStepMax = 0.008
 MPPVoltageStepMin = 0.00025
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "Trinamic"
 model = "TMCM-1160"

--- a/config/examples/ivlab_indoor.toml
+++ b/config/examples/ivlab_indoor.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 # Manual lamp: no hardware control — user adjusts light level physically.
 brand = "manual"

--- a/config/examples/ivlab_wavelabs.toml
+++ b/config/examples/ivlab_wavelabs.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "Wavelabs"
 model = "Sinus70"

--- a/config/examples/old_iv.toml
+++ b/config/examples/old_iv.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "manual"
 model = "manual"

--- a/config/examples/oriel_iv.toml
+++ b/config/examples/oriel_iv.toml
@@ -23,6 +23,12 @@ MPPVoltageStepInitial = 0.002        # volts — initial MPP tracker step
 MPPVoltageStepMax = 0.002            # volts — maximum MPP tracker step
 MPPVoltageStepMin = 0.001            # volts — minimum MPP tracker step
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "Trinamic"
 model = "TMCM-1260"                  # single-axis stepper controller

--- a/config/examples/sinus70_1.toml
+++ b/config/examples/sinus70_1.toml
@@ -19,6 +19,12 @@ MPPVoltageStepInitial = 0.002
 MPPVoltageStepMax = 0.002
 MPPVoltageStepMin = 0.001
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "Wavelabs"
 model = "Sinus70"

--- a/config/examples/verasol_glovebox.toml
+++ b/config/examples/verasol_glovebox.toml
@@ -27,6 +27,12 @@ MPPVoltageStepInitial = 0.002         # volts — initial MPP tracker step
 MPPVoltageStepMax = 0.002             # volts — maximum MPP tracker step
 MPPVoltageStepMin = 0.001             # volts — minimum MPP tracker step
 
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
 [lamp]
 brand = "VeraSol"
 model = "LSS-7120"                    # 19-channel LED solar simulator, USB/USBTMC

--- a/src/iv_lab/config/settings.py
+++ b/src/iv_lab/config/settings.py
@@ -55,6 +55,10 @@ class IVSystemSettings(LegacyCompatibleModel):
     MPPVoltageStepInitial: float = 0.002
     MPPVoltageStepMax: float = 0.002
     MPPVoltageStepMin: float = 0.001
+    #: Calibration (control) diodes selectable in the GUI calibration panel:
+    #: name -> certified Iref in mA. Optional; the panel falls back to a
+    #: built-in default when absent.
+    calibrationDiodes: dict[str, float] | None = None
 
 
 class LampSettings(LegacyCompatibleModel):

--- a/src/iv_lab/gui/main_window.py
+++ b/src/iv_lab/gui/main_window.py
@@ -170,6 +170,7 @@ class MainWindow(QMainWindow):
         self._connect_panels()
         self._connect_system()
         self._configure_light_panel()
+        self._configure_calibration_diodes()
         self._register_config_fields()
 
     # --- wiring ---
@@ -212,6 +213,12 @@ class MainWindow(QMainWindow):
             else:
                 light_levels[f"{level:4.1f} % Sun"] = level
         self.light_panel.set_light_level_list(light_levels)
+
+    def _configure_calibration_diodes(self) -> None:
+        """Load selectable calibration diodes (name -> Iref in mA) from the
+        ``IVsys.calibrationDiodes`` settings; empty keeps the panel default."""
+        diodes = self.system.settings.IVsys.calibrationDiodes or {}
+        self.measurement_panel.calibration_panel.set_diode_list(diodes)
 
     # --- error / warning display (legacy showErrorMessage / error_window) ---
 

--- a/src/iv_lab/gui/panels/calibration_panel.py
+++ b/src/iv_lab/gui/panels/calibration_panel.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QDoubleValidator
 from PySide6.QtWidgets import (
+    QComboBox,
     QGridLayout,
     QLabel,
     QLineEdit,
@@ -28,12 +29,28 @@ class CalibrationPanel(QWidget):
     abort_clicked = Signal()
     save_clicked = Signal()
 
+    #: Built-in fallback calibration diodes (name -> certified Iref in mA), used
+    #: when the settings file provides none. Selecting a diode fills the Iref
+    #: field and locks it; ``MANUAL_LABEL`` unlocks it for typing. Replace the
+    #: list at runtime from settings via :meth:`set_diode_list`.
+    DEFAULT_DIODES = {"Si1812": 1.541}
+    MANUAL_LABEL = "Manual value"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setMaximumWidth(300)
 
+        #: Calibration diode selector: a named diode applies its certified Iref,
+        #: "Manual value" lets the user enter Iref by hand.
+        self.combo_diode_type = QComboBox()
+        #: Selectable diodes (name -> certified Iref in mA); set_diode_list()
+        #: replaces this from the settings file.
+        self.diode_dict: dict[str, float] = dict(self.DEFAULT_DIODES)
+
         #: Certified current of the calibration (control) diode in mA.
         self.field_diode_reference_current = _double_field("1.00")
+        self.combo_diode_type.currentTextChanged.connect(self._on_diode_type_changed)
+        self._populate_diode_combo()
         self.field_stabilization_time = _double_field("5.0")
         self.field_interval = _double_field("0.50")
         self.field_duration = _double_field("60.0")
@@ -51,18 +68,20 @@ class CalibrationPanel(QWidget):
         self.button_save.setEnabled(False)
 
         fields = QGridLayout()
-        fields.addWidget(QLabel("Calibration Diode Iref"), 0, 0)
-        fields.addWidget(self.field_diode_reference_current, 0, 1)
-        fields.addWidget(QLabel("mA"), 0, 2)
-        fields.addWidget(QLabel("Stabilization Time"), 1, 0)
-        fields.addWidget(self.field_stabilization_time, 1, 1)
-        fields.addWidget(QLabel("sec"), 1, 2)
-        fields.addWidget(QLabel("Meas Interval"), 2, 0)
-        fields.addWidget(self.field_interval, 2, 1)
+        fields.addWidget(QLabel("Calibration Diode"), 0, 0)
+        fields.addWidget(self.combo_diode_type, 0, 1, 1, 2)
+        fields.addWidget(QLabel("Calibration Diode Iref"), 1, 0)
+        fields.addWidget(self.field_diode_reference_current, 1, 1)
+        fields.addWidget(QLabel("mA"), 1, 2)
+        fields.addWidget(QLabel("Stabilization Time"), 2, 0)
+        fields.addWidget(self.field_stabilization_time, 2, 1)
         fields.addWidget(QLabel("sec"), 2, 2)
-        fields.addWidget(QLabel("Meas Duration"), 3, 0)
-        fields.addWidget(self.field_duration, 3, 1)
+        fields.addWidget(QLabel("Meas Interval"), 3, 0)
+        fields.addWidget(self.field_interval, 3, 1)
         fields.addWidget(QLabel("sec"), 3, 2)
+        fields.addWidget(QLabel("Meas Duration"), 4, 0)
+        fields.addWidget(self.field_duration, 4, 1)
+        fields.addWidget(QLabel("sec"), 4, 2)
 
         reference = QGridLayout()
         reference.addWidget(QLabel("Reference Diode Iref"), 0, 0)
@@ -76,6 +95,29 @@ class CalibrationPanel(QWidget):
         layout.addLayout(reference)
         layout.addWidget(self.button_save)
         self.setLayout(layout)
+
+    def set_diode_list(self, diodes: dict[str, float]) -> None:
+        """Populate the diode dropdown from the settings file (name -> certified
+        Iref in mA). An empty mapping keeps the built-in default."""
+        if diodes:
+            self.diode_dict = dict(diodes)
+        self._populate_diode_combo()
+
+    def _populate_diode_combo(self) -> None:
+        """Rebuild the dropdown from ``diode_dict`` and apply the selection."""
+        self.combo_diode_type.blockSignals(True)
+        self.combo_diode_type.clear()
+        self.combo_diode_type.addItems([*self.diode_dict, self.MANUAL_LABEL])
+        self.combo_diode_type.blockSignals(False)
+        self._on_diode_type_changed(self.combo_diode_type.currentText())
+
+    def _on_diode_type_changed(self, name: str) -> None:
+        """Apply the selected diode: a known diode fills Iref (mA) and locks the
+        field; "Manual value" unlocks it for hand entry."""
+        certified = self.diode_dict.get(name)
+        if certified is not None:
+            self.field_diode_reference_current.setText(f"{certified:.3f}")
+        self.field_diode_reference_current.setReadOnly(certified is not None)
 
     def set_reference_current(self, current_ma: float) -> None:
         """Show the derived current (legacy ``setCalibrationReferenceCurrent``,

--- a/tests/test_gui_measurement_panel.py
+++ b/tests/test_gui_measurement_panel.py
@@ -174,6 +174,67 @@ def test_calibration_params_and_save() -> None:
     assert recorder.calibration_saves[0]["reference_current"] == pytest.approx(0.00412)
 
 
+def test_calibration_diode_dropdown_si1812() -> None:
+    panel = make_panel()
+    cal = panel.calibration_panel
+
+    # defaults to the first named diode (Si1812): Iref filled and locked
+    assert cal.combo_diode_type.currentText() == "Si1812"
+    assert cal.field_diode_reference_current.text() == "1.541"
+    assert cal.field_diode_reference_current.isReadOnly()
+
+
+def test_calibration_diode_dropdown_manual_unlocks() -> None:
+    panel = make_panel()
+    cal = panel.calibration_panel
+
+    cal.combo_diode_type.setCurrentText(cal.MANUAL_LABEL)
+    assert not cal.field_diode_reference_current.isReadOnly()
+
+    # a manually entered value flows through to the calibration run
+    cal.field_diode_reference_current.setText("2.00")
+    cal.combo_diode_type.setCurrentText("Si1812")  # re-locks and overrides
+    assert cal.field_diode_reference_current.text() == "1.541"
+    assert cal.field_diode_reference_current.isReadOnly()
+
+
+def test_calibration_set_diode_list_from_settings() -> None:
+    panel = make_panel()
+    cal = panel.calibration_panel
+
+    cal.set_diode_list({"Si1812": 1.541, "KG3-7": 2.20})
+
+    items = [cal.combo_diode_type.itemText(i) for i in range(cal.combo_diode_type.count())]
+    assert items == ["Si1812", "KG3-7", cal.MANUAL_LABEL]
+    # first configured diode is applied and locked
+    assert cal.combo_diode_type.currentText() == "Si1812"
+    assert cal.field_diode_reference_current.text() == "1.541"
+
+    cal.combo_diode_type.setCurrentText("KG3-7")
+    assert cal.field_diode_reference_current.text() == "2.200"
+    assert cal.field_diode_reference_current.isReadOnly()
+
+
+def test_calibration_set_diode_list_empty_keeps_default() -> None:
+    panel = make_panel()
+    cal = panel.calibration_panel
+
+    cal.set_diode_list({})  # no diodes configured -> built-in default
+
+    assert cal.combo_diode_type.currentText() == "Si1812"
+    assert cal.field_diode_reference_current.text() == "1.541"
+
+
+def test_calibration_si1812_drives_reference_current() -> None:
+    panel = make_panel()
+    recorder = Recorder(panel)
+
+    panel._run_calibration()  # Si1812 selected by default
+
+    _, params = recorder.runs[0]
+    assert params["reference_current"] == pytest.approx(0.001541)  # 1.541 mA -> A
+
+
 def test_calibration_menu_entry_toggles() -> None:
     panel = make_panel()
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -89,6 +89,21 @@ def test_extra_legacy_fields_are_allowed(tmp_path: Path) -> None:
     assert settings.futureSection == {"a": 1}
 
 
+def test_calibration_diodes_are_parsed(tmp_path: Path) -> None:
+    data = json.loads(json.dumps(MINIMAL_SETTINGS))
+    data["IVsys"]["calibrationDiodes"] = {"Si1812": 1.541, "KG3-7": 2.2}
+
+    settings = load_settings(write_settings(tmp_path, data))
+
+    assert settings.IVsys.calibrationDiodes == {"Si1812": 1.541, "KG3-7": 2.2}
+
+
+def test_calibration_diodes_optional(tmp_path: Path) -> None:
+    settings = load_settings(write_settings(tmp_path, MINIMAL_SETTINGS))
+
+    assert settings.IVsys.calibrationDiodes is None
+
+
 def test_missing_required_field_gives_useful_error(tmp_path: Path) -> None:
     data = json.loads(json.dumps(MINIMAL_SETTINGS))
     del data["IVsys"]["fullSunReferenceCurrent"]


### PR DESCRIPTION
Adds a **Calibration Diode** dropdown to the calibration panel, with the diode list defined in the settings file.

## Behavior
- Dropdown above the "Calibration Diode Iref" field, populated from settings plus a `Manual value` entry.
- Selecting a named diode (e.g. **Si1812**) fills Iref with its certified current (mA) and **locks** the field.
- `Manual value` unlocks the field for hand entry.

## Config-driven
- New optional `IVsys.calibrationDiodes` mapping (`name -> Iref in mA`):
  ```toml
  [IVsys.calibrationDiodes]
  "Si1812" = 1.541
  ```
- Wired into the panel exactly like `lamp.lightLevelDict` feeds the light-level dropdown: `main_window._configure_calibration_diodes()` → `CalibrationPanel.set_diode_list()`.
- Panel keeps a built-in fallback (`Si1812 = 1.541`) when settings provide none, so it works standalone.
- Added the mapping to `config/examples/verasol_glovebox.toml` (and the local glovebox runtime config).

## Tests
- Dropdown defaults, lock/unlock, run-param flow, `set_diode_list` from settings, empty-keeps-default, and `IVsys.calibrationDiodes` parsing (present + absent).
- Full suite: 412 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)