### PR TITLE
feat: robust settings/users discovery for installed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,103 @@ python -m iv_lab.main
 
 ---
 
+## Installing as a package (pip)
+
+The Quick start above runs the app from a checkout of this repository. You can
+also install `iv_lab` as a normal Python package and launch it from anywhere
+with the `iv-lab` command. Because the package ships **no** machine-specific
+files (settings, users, logo), there are a few one-time setup steps.
+
+### 1. Install
+
+```powershell
+# From a clone of this repository:
+pip install .
+
+# …or straight from GitHub (no clone needed):
+pip install "git+https://github.com/EPFL-LPI/iv_lab.git"
+
+# Add the instrument-control libraries for real hardware (omit for emulation):
+pip install ".[hardware]"
+```
+
+This puts an **`iv-lab`** command on your PATH — equivalent to
+`python -m iv_lab.main`, with the same options.
+
+### 2. Pick where your config lives
+
+When you run `iv-lab` **without** `--settings`, it looks for the settings file
+in this order:
+
+1. the `IV_LAB_SETTINGS` environment variable (a full path to the file),
+2. `./config/system_settings.toml` in the current working directory,
+3. the per-user config directory:
+   - **Windows:** `%APPDATA%\iv_lab\system_settings.toml`
+   - **Linux/macOS:** `~/.config/iv_lab/system_settings.toml` (honours `$XDG_CONFIG_HOME`).
+
+The **per-user directory is recommended** for an installed app: it survives
+package upgrades and works no matter which folder you launch from. Create it:
+
+```powershell
+# Windows
+mkdir "$env:APPDATA\iv_lab"
+```
+
+### 3. Add your settings file
+
+Copy the example that matches your hardware (from this repo's
+[`config/examples/`](config/examples/)) into that directory as
+`system_settings.toml`, then edit it:
+
+```powershell
+copy config\examples\oriel_iv.toml "$env:APPDATA\iv_lab\system_settings.toml"
+notepad "$env:APPDATA\iv_lab\system_settings.toml"
+```
+
+Edit at least `basePath`, `sdPath`, and the SMU `visa_address` — see
+[System settings](#system-settings) for the key fields. If you installed
+without cloning, download an example from
+[`config/examples/`](config/examples/) on GitHub first.
+
+### 4. Add a users file
+
+Login requires a users table, and the package ships none — without one the app
+reports *"User table corrupted or absent."* Create a `users.txt` in the **same
+per-user directory** with at least the generic account, using the
+[`write_users` snippet](#adding-named-users) but pointing the path at, e.g.,
+`%APPDATA%\iv_lab\users.txt` and including `"user": "123456"`. `iv-lab` finds
+`users.txt` there automatically (same search order as the settings file).
+
+The generic login (blank username, or `user` / `123456`) then works out of the
+box; add named accounts as described under [User management](#user-management).
+
+### 5. (Optional) report logo
+
+PDF reports look for `EPFL_Logo.png` in the directory you launch from, or use
+`--logo PATH`. Reports render fine without it.
+
+### 6. Run it
+
+```powershell
+# Emulation (no instruments; still uses the settings file from step 3):
+iv-lab --emulate
+
+# Real hardware:
+iv-lab
+```
+
+To pin the settings file regardless of the working directory, set the
+environment variable once (then `iv-lab` needs no flags from any folder):
+
+```powershell
+setx IV_LAB_SETTINGS "%APPDATA%\iv_lab\system_settings.toml"
+```
+
+Calibration values you set in the app are written back into this same
+`system_settings.toml` automatically.
+
+---
+
 ## System settings
 
 Machine-specific configuration lives in `config/system_settings.toml` (gitignored).  

--- a/src/iv_lab/config/__init__.py
+++ b/src/iv_lab/config/__init__.py
@@ -1,3 +1,8 @@
+from .discovery import (
+    SETTINGS_ENV_VAR,
+    resolve_settings_file,
+    user_config_dir,
+)
 from .settings import (
     DEFAULT_SETTINGS_FILENAME,
     ArduinoSettings,
@@ -12,6 +17,7 @@ from .settings import (
 
 __all__ = [
     "DEFAULT_SETTINGS_FILENAME",
+    "SETTINGS_ENV_VAR",
     "ArduinoSettings",
     "ComputerSettings",
     "IVSystemSettings",
@@ -19,5 +25,7 @@ __all__ = [
     "SMUSettings",
     "SystemSettings",
     "load_settings",
+    "resolve_settings_file",
     "save_settings",
+    "user_config_dir",
 ]

--- a/src/iv_lab/config/discovery.py
+++ b/src/iv_lab/config/discovery.py
@@ -1,0 +1,60 @@
+"""Locate machine-specific config files when iv_lab runs as an installed package.
+
+When the app is installed with ``pip`` (rather than run from a checkout) the
+settings and users files live outside the package. These helpers find them via
+an ordered search so ``iv-lab`` works regardless of the working directory:
+
+1. an explicit path (``--settings`` / ``--users``),
+2. the ``IV_LAB_SETTINGS`` environment variable (settings only),
+3. the working-directory ``config/`` folder (the original behavior),
+4. a per-user config directory: ``%APPDATA%\\iv_lab`` on Windows,
+   ``$XDG_CONFIG_HOME/iv_lab`` (or ``~/.config/iv_lab``) elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .settings import DEFAULT_SETTINGS_FILENAME
+
+#: Environment variable holding an explicit path to the settings file.
+SETTINGS_ENV_VAR = "IV_LAB_SETTINGS"
+
+#: Application subdirectory inside the per-user config directory.
+APP_DIR_NAME = "iv_lab"
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def user_config_dir() -> Path:
+    """Return the per-user config directory for iv_lab (platform-appropriate)."""
+    if _is_windows():
+        base = os.environ.get("APPDATA")
+        root = Path(base) if base else Path.home() / "AppData" / "Roaming"
+    else:
+        base = os.environ.get("XDG_CONFIG_HOME")
+        root = Path(base) if base else Path.home() / ".config"
+    return root / APP_DIR_NAME
+
+
+def resolve_settings_file(explicit: str | None) -> Path:
+    """Locate the settings file using the ordered search above.
+
+    Falls back to the working-directory default (``config/system_settings.toml``,
+    which may not exist) so a missing-file error names a familiar location.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    env = os.environ.get(SETTINGS_ENV_VAR)
+    if env:
+        return Path(env)
+    cwd_default = Path(DEFAULT_SETTINGS_FILENAME)
+    if cwd_default.exists():
+        return cwd_default
+    user = user_config_dir() / Path(DEFAULT_SETTINGS_FILENAME).name
+    if user.exists():
+        return user
+    return cwd_default

--- a/src/iv_lab/main.py
+++ b/src/iv_lab/main.py
@@ -20,7 +20,9 @@ import argparse
 import sys
 from pathlib import Path
 
-from iv_lab.config import DEFAULT_SETTINGS_FILENAME, load_settings
+from iv_lab.config import resolve_settings_file, user_config_dir
+from iv_lab.config.discovery import SETTINGS_ENV_VAR
+from iv_lab.config.settings import DEFAULT_SETTINGS_FILENAME, load_settings
 from iv_lab.services.auth import USERS_FILENAME, USERS_GENERIC_FILENAME
 
 #: Legacy report logo file (in the working directory, as in legacy).
@@ -30,13 +32,17 @@ DEFAULT_LOGO_FILENAME = "EPFL_Logo.png"
 def resolve_users_file(explicit: str | None) -> Path:
     """Return the users file to load, applying the fallback chain.
 
-    Priority: explicit --users arg → config/users.txt (if exists) → config/users_generic.txt
+    Priority: explicit --users arg → config/users.txt (working dir) →
+    <user config dir>/users.txt → config/users_generic.txt
     """
     if explicit is not None:
         return Path(explicit)
     primary = Path(USERS_FILENAME)
     if primary.exists():
         return primary
+    user = user_config_dir() / Path(USERS_FILENAME).name
+    if user.exists():
+        return user
     return Path(USERS_GENERIC_FILENAME)
 
 
@@ -47,8 +53,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--settings",
-        default=DEFAULT_SETTINGS_FILENAME,
-        help="system settings file (default: %(default)s in the working directory)",
+        default=None,
+        help=(
+            "system settings file; if omitted the app looks at "
+            f"${SETTINGS_ENV_VAR}, then ./{DEFAULT_SETTINGS_FILENAME}, then the "
+            "per-user config directory"
+        ),
     )
     parser.add_argument(
         "--users",
@@ -78,10 +88,16 @@ def main(argv: list[str] | None = None, *, exec_app: bool = True) -> int:
     """
     args = parse_args(argv)
 
+    settings_path = resolve_settings_file(args.settings)
     try:
-        settings = load_settings(args.settings)
+        settings = load_settings(settings_path)
     except FileNotFoundError:
-        print(f"ERROR: settings file not found: {args.settings}", file=sys.stderr)
+        print(f"ERROR: settings file not found: {settings_path}", file=sys.stderr)
+        print(
+            f"Provide one with --settings PATH, set {SETTINGS_ENV_VAR}, or place it at "
+            f"{user_config_dir() / Path(DEFAULT_SETTINGS_FILENAME).name}",
+            file=sys.stderr,
+        )
         return 1
     except Exception as exc:
         print(f"ERROR: could not load settings: {exc}", file=sys.stderr)
@@ -99,7 +115,7 @@ def main(argv: list[str] | None = None, *, exec_app: bool = True) -> int:
 
     app, window = launch(
         settings,
-        settings_file=args.settings,
+        settings_file=settings_path,
         users_file=users_file,
         logo_path=args.logo,
     )

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -1,0 +1,75 @@
+"""Tests for settings-file discovery when running as an installed package."""
+
+from pathlib import Path
+
+from iv_lab.config.discovery import (
+    DEFAULT_SETTINGS_FILENAME,
+    SETTINGS_ENV_VAR,
+    resolve_settings_file,
+    user_config_dir,
+)
+
+
+def test_explicit_path_wins(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(SETTINGS_ENV_VAR, str(tmp_path / "env.toml"))
+    explicit = tmp_path / "explicit.toml"
+
+    assert resolve_settings_file(str(explicit)) == explicit
+
+
+def test_env_var_used_when_no_explicit(monkeypatch, tmp_path: Path) -> None:
+    env_path = tmp_path / "from_env.toml"
+    monkeypatch.setenv(SETTINGS_ENV_VAR, str(env_path))
+
+    assert resolve_settings_file(None) == env_path
+
+
+def test_cwd_config_used_when_present(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(SETTINGS_ENV_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    cwd_file = tmp_path / DEFAULT_SETTINGS_FILENAME
+    cwd_file.parent.mkdir(parents=True)
+    cwd_file.write_text("")
+
+    assert resolve_settings_file(None) == Path(DEFAULT_SETTINGS_FILENAME)
+
+
+def test_user_config_dir_fallback(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(SETTINGS_ENV_VAR, raising=False)
+    # an empty working directory so the CWD candidate does not exist
+    empty_cwd = tmp_path / "empty"
+    empty_cwd.mkdir()
+    monkeypatch.chdir(empty_cwd)
+
+    user_dir = tmp_path / "user_cfg"
+    user_file = user_dir / "system_settings.toml"
+    user_dir.mkdir()
+    user_file.write_text("")
+    monkeypatch.setattr("iv_lab.config.discovery.user_config_dir", lambda: user_dir)
+
+    assert resolve_settings_file(None) == user_file
+
+
+def test_falls_back_to_cwd_default_when_nothing_found(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(SETTINGS_ENV_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "iv_lab.config.discovery.user_config_dir", lambda: tmp_path / "nonexistent"
+    )
+
+    # nothing exists: returns the working-directory default for a familiar error
+    assert resolve_settings_file(None) == Path(DEFAULT_SETTINGS_FILENAME)
+
+
+def test_user_config_dir_windows(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("iv_lab.config.discovery._is_windows", lambda: True)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "Roaming"))
+
+    assert user_config_dir() == tmp_path / "Roaming" / "iv_lab"
+
+
+def test_user_config_dir_posix_xdg(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("iv_lab.config.discovery._is_windows", lambda: False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    assert user_config_dir() == tmp_path / "xdg" / "iv_lab"

--- a/tests/test_main_entry.py
+++ b/tests/test_main_entry.py
@@ -40,7 +40,7 @@ def write_settings(tmp_path: Path, emulate: bool) -> Path:
 def test_parse_args_defaults() -> None:
     args = parse_args([])
 
-    assert args.settings == "config/system_settings.toml"
+    assert args.settings is None  # resolved later via resolve_settings_file
     assert args.users is None
     assert args.logo == "EPFL_Logo.png"
     assert not args.emulate


### PR DESCRIPTION
Makes an installed `iv-lab` find its machine-specific config regardless of the working directory.

## Problem
The `--settings` default was the **CWD-relative** `config/system_settings.toml`. After `pip install`, launching `iv-lab` from any other directory silently failed to find settings.

## Discovery chain (settings)
When `--settings` is omitted, search in order:
1. `IV_LAB_SETTINGS` environment variable
2. `./config/system_settings.toml` (working dir — original behavior, preserved)
3. `<user config dir>/system_settings.toml`

Per-user config dir: `%APPDATA%\iv_lab` (Windows), `$XDG_CONFIG_HOME/iv_lab` or `~/.config/iv_lab` (POSIX).

The users-file fallback gains the same `<user config dir>/users.txt` step, so a single data folder can hold settings + users.

## Changes
- New `iv_lab/config/discovery.py`: `resolve_settings_file()`, `user_config_dir()`, `SETTINGS_ENV_VAR`.
- `--settings` now defaults to `None`, resolved through the chain in `main()`.
- Missing-file error now names the env var and the per-user location.
- `--help` text updated to describe the chain.

## Tests
- New `test_config_discovery.py`: explicit > env > CWD > user-dir precedence, final fallback, and the Windows/POSIX dir logic.
- Full suite: 419 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)