### PR TITLE
feat: add iv-lab --init to scaffold per-user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,25 @@ pip install ".[hardware]"
 This puts an **`iv-lab`** command on your PATH — equivalent to
 `python -m iv_lab.main`, with the same options.
 
-### 2. Pick where your config lives
+### 2. Scaffold your config (recommended)
+
+```powershell
+iv-lab --init
+```
+
+This creates the per-user config directory and seeds it with:
+
+- an **emulation-ready** `system_settings.toml` (so `iv-lab` runs immediately
+  without instruments — edit it for your hardware),
+- a starter `users.txt` with the generic `user` / `123456` login.
+
+It never overwrites existing files, so re-running it is safe. It prints the
+exact directory it used; you can then jump to step 6 to run the app, and edit
+the settings file when you connect real hardware. The manual steps 2–4 below
+explain what `--init` sets up if you prefer to do it by hand or start from one
+of the per-system examples.
+
+### 2b. (Manual alternative) Pick where your config lives
 
 When you run `iv-lab` **without** `--settings`, it looks for the settings file
 in this order:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ hardware = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+# Bundled starter template copied by `iv-lab --init`.
+"iv_lab.resources" = ["*.toml"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/src/iv_lab/main.py
+++ b/src/iv_lab/main.py
@@ -78,6 +78,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="force emulation of all hardware, regardless of the settings file",
     )
+    parser.add_argument(
+        "--init",
+        action="store_true",
+        help=(
+            "create a starter system_settings.toml and users.txt in the per-user "
+            "config directory, then exit (does not overwrite existing files)"
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -87,6 +95,13 @@ def main(argv: list[str] | None = None, *, exec_app: bool = True) -> int:
     ``exec_app=False`` skips the Qt event loop (used by tests).
     """
     args = parse_args(argv)
+
+    if args.init:
+        from iv_lab.scaffold import scaffold_user_config
+
+        for line in scaffold_user_config():
+            print(line)
+        return 0
 
     settings_path = resolve_settings_file(args.settings)
     try:

--- a/src/iv_lab/resources/__init__.py
+++ b/src/iv_lab/resources/__init__.py
@@ -1,0 +1,5 @@
+"""Bundled, non-machine-specific resource files shipped inside the package.
+
+Currently holds the emulation-ready ``system_settings.toml`` starter template
+that ``iv-lab --init`` copies into the per-user config directory.
+"""

--- a/src/iv_lab/resources/system_settings.toml
+++ b/src/iv_lab/resources/system_settings.toml
@@ -1,0 +1,49 @@
+# iv_lab starter configuration (created by `iv-lab --init`).
+#
+# This file is EMULATION-READY: every device has emulate = true, so `iv-lab`
+# runs without any instruments connected. To drive real hardware, set the
+# emulate flags to false and fill in the real addresses below.
+#
+# Ready-made per-system templates (Wavelabs, Oriel, Trinamic, VeraSol, …) live
+# in the config/examples/ folder of the iv_lab repository on GitHub.
+
+[computer]
+hardware = "iv_lab"                   # free label, used in log files
+os = "Windows 11"
+basePath = "C:\\Data"                  # root directory for measurement data
+sdPath = ""                            # scrambled backup copy directory; "" disables
+
+[IVsys]
+sysName = "IVLab"
+# fullSunReferenceCurrent is updated automatically each time you run a calibration.
+fullSunReferenceCurrent = 0.006129    # amps — reference diode current at 1 sun
+calibrationDateTime = ""
+referenceDiodeImax = 0.01             # amps — current compliance for reference diode channel
+saveDataAutomatic = false             # true = auto-save after each scan; false = prompt
+checkVOCBeforeScan = true             # measure Voc before each scan to verify illumination
+firstPointDwellTime = 5.0             # seconds — settling time at first voltage point
+MPPVoltageStepInitial = 0.002         # volts — initial MPP tracker step
+MPPVoltageStepMax = 0.002             # volts — maximum MPP tracker step
+MPPVoltageStepMin = 0.001             # volts — minimum MPP tracker step
+
+# Calibration (control) diodes offered in the calibration panel drop-down.
+# Keys = name shown in the dropdown; values = certified Iref in mA.
+# Pick "Manual value" in the GUI to type an Iref by hand instead.
+[IVsys.calibrationDiodes]
+"Si1812" = 1.541
+
+[lamp]
+brand = "manual"                      # "manual", "Wavelabs", "Oriel", "Trinamic", "VeraSol", …
+model = "manual"
+"display name" = "Manual lamp"
+emulate = true                        # set false to drive a real lamp
+
+[SMU]
+brand = "Keithley"
+model = "2400"                        # 2400 | 2401 | 2450 | 2602 …
+visa_address = "GPIB0::24::INSTR"     # adjust to your instrument (e.g. ASRL4::INSTR for COM4)
+visa_library = "@py"                  # pyvisa-py backend; or path to visa32.dll for NI-VISA
+emulate = true                        # set false to drive a real SMU
+referenceDiodeSenseMode = "2wire"     # "2wire" or "4 wire"
+autorange = true
+useReferenceDiode = true              # measure reference diode on channel B during scans

--- a/src/iv_lab/scaffold.py
+++ b/src/iv_lab/scaffold.py
@@ -1,0 +1,57 @@
+"""Scaffold a per-user config directory for an installed package.
+
+Backs ``iv-lab --init``: creates the per-user config directory and seeds it
+with an emulation-ready ``system_settings.toml`` and a starter ``users.txt``
+(the generic ``user`` / ``123456`` account). Existing files are never
+overwritten, so re-running ``--init`` is safe.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+
+from iv_lab.config import user_config_dir
+from iv_lab.services.auth import GENERIC_PASSWORD, GENERIC_USERNAME, write_users
+
+SETTINGS_NAME = "system_settings.toml"
+USERS_NAME = "users.txt"
+
+
+def settings_template() -> str:
+    """Return the bundled emulation-ready settings template text."""
+    return (
+        resources.files("iv_lab.resources")
+        .joinpath(SETTINGS_NAME)
+        .read_text(encoding="utf-8")
+    )
+
+
+def scaffold_user_config(target: Path | None = None) -> list[str]:
+    """Create ``system_settings.toml`` and ``users.txt`` in *target*.
+
+    *target* defaults to the per-user config directory. Existing files are left
+    untouched. Returns human-readable status lines describing what happened.
+    """
+    target = Path(target) if target is not None else user_config_dir()
+    target.mkdir(parents=True, exist_ok=True)
+    lines = [f"Config directory: {target}"]
+
+    settings_path = target / SETTINGS_NAME
+    if settings_path.exists():
+        lines.append(f"  kept    {SETTINGS_NAME} (already exists)")
+    else:
+        settings_path.write_text(settings_template(), encoding="utf-8")
+        lines.append(f"  created {SETTINGS_NAME} (emulation-ready; edit for your hardware)")
+
+    users_path = target / USERS_NAME
+    if users_path.exists():
+        lines.append(f"  kept    {USERS_NAME} (already exists)")
+    else:
+        write_users(users_path, {GENERIC_USERNAME: GENERIC_PASSWORD})
+        lines.append(f"  created {USERS_NAME} (generic '{GENERIC_USERNAME}' login)")
+
+    lines.append("")
+    lines.append("Next: edit the settings file for your instruments, then run `iv-lab`.")
+    lines.append("Try it now without hardware:  iv-lab --emulate")
+    return lines

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,57 @@
+"""Tests for `iv-lab --init` config scaffolding."""
+
+from pathlib import Path
+
+from iv_lab.config.settings import load_settings
+from iv_lab.main import main
+from iv_lab.scaffold import scaffold_user_config, settings_template
+from iv_lab.services.auth import GENERIC_PASSWORD, GENERIC_USERNAME, load_users
+
+
+def test_bundled_template_is_emulation_ready(tmp_path: Path) -> None:
+    path = tmp_path / "system_settings.toml"
+    path.write_text(settings_template(), encoding="utf-8")
+
+    settings = load_settings(path)
+
+    assert settings.SMU.emulate is True
+    assert settings.lamp.emulate is True
+    assert settings.IVsys.calibrationDiodes == {"Si1812": 1.541}
+
+
+def test_scaffold_creates_both_files(tmp_path: Path) -> None:
+    lines = scaffold_user_config(tmp_path)
+
+    settings_path = tmp_path / "system_settings.toml"
+    users_path = tmp_path / "users.txt"
+    assert settings_path.exists()
+    assert users_path.exists()
+    assert "created system_settings.toml" in "\n".join(lines)
+
+    # the seeded settings load and the generic account is present
+    assert load_settings(settings_path).SMU.emulate is True
+    assert load_users(users_path)[GENERIC_USERNAME] == GENERIC_PASSWORD
+
+
+def test_scaffold_does_not_overwrite(tmp_path: Path) -> None:
+    settings_path = tmp_path / "system_settings.toml"
+    settings_path.write_text("# my edited config\n", encoding="utf-8")
+
+    lines = scaffold_user_config(tmp_path)
+
+    assert settings_path.read_text(encoding="utf-8") == "# my edited config\n"
+    assert "kept    system_settings.toml" in "\n".join(lines)
+
+
+def test_init_flag_scaffolds_user_config(tmp_path, monkeypatch, capsys) -> None:
+    # user_config_dir() reads APPDATA on Windows / XDG elsewhere; point both at tmp
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    exit_code = main(["--init"], exec_app=False)
+
+    assert exit_code == 0
+    target = tmp_path / "iv_lab"
+    assert (target / "system_settings.toml").exists()
+    assert (target / "users.txt").exists()
+    assert "Config directory" in capsys.readouterr().out


### PR DESCRIPTION
Adds a one-step first-run setup for installed (pip) users.

## `iv-lab --init`
Creates the per-user config directory (`%APPDATA%\iv_lab` / `~/.config/iv_lab`) and seeds it with:
- an **emulation-ready** `system_settings.toml` (runs immediately without instruments; edit for real hardware),
- a starter `users.txt` with the generic `user` / `123456` login.

Existing files are never overwritten, so re-running is safe. It prints the directory it used and next steps.

## How it works
- The starter template is **bundled in the package** (`src/iv_lab/resources/system_settings.toml`, shipped via `[tool.setuptools.package-data]`), so it works for `pip install`-only users with no checkout. Verified present in the built wheel.
- New `iv_lab/scaffold.py` (`scaffold_user_config`, `settings_template`); `--init` flag in the CLI returns before settings resolution / GUI import, so it runs headless.
- README: `--init` documented as the recommended step 2 of the pip install flow.

## Tests
- Bundled template is emulation-ready and loads; scaffold creates both files; idempotent (no overwrite); `--init` flag end-to-end with a redirected config dir.
- Full suite: 423 passed; ruff clean; wheel build confirmed to include the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)