### PR TITLE
feat: show measured light intensity right after the reference reading

### DIFF
--- a/src/iv_lab/core/system.py
+++ b/src/iv_lab/core/system.py
@@ -162,6 +162,9 @@ class IVLabSystem(QObject):
     warning_confirmation_needed = Signal(str, float)
     error_message = Signal(str)
     data_updated = Signal(dict)
+    #: Measured light intensity in % sun, emitted right after the reference
+    #: diode reading and before the electrical measurement begins.
+    light_intensity_measured = Signal(float)
     progress_updated = Signal(int)
     measurement_started = Signal(str)  # scan-type label
     measurement_finished = Signal(object)  # result dataclass
@@ -422,6 +425,7 @@ class IVLabSystem(QObject):
         worker.status_update.connect(self.status_message)
         worker.warning_update.connect(self.warning_message)
         worker.data_ready.connect(self.data_updated)
+        worker.light_intensity_ready.connect(self.light_intensity_measured)
         worker.progress_update.connect(self.progress_updated)
         worker.finished.connect(
             lambda result, spec=spec: self._on_worker_finished(spec, result)

--- a/src/iv_lab/gui/main_window.py
+++ b/src/iv_lab/gui/main_window.py
@@ -192,6 +192,9 @@ class MainWindow(QMainWindow):
         system.warning_message.connect(self._show_warning)
         system.warning_confirmation_needed.connect(self._show_warning_confirmation)
         system.data_updated.connect(self.plot_panel.update_live_data)
+        system.light_intensity_measured.connect(
+            self.light_panel.update_measured_intensity
+        )
         system.measurement_finished.connect(self._on_measurement_finished)
         system.calibration_ready.connect(self._on_calibration_ready)
         system.hardware_ready.connect(self._on_hardware_ready)

--- a/src/iv_lab/measurements/protocols/base.py
+++ b/src/iv_lab/measurements/protocols/base.py
@@ -79,6 +79,7 @@ class MeasurementProtocol(ABC):
         warning_callback: Callable[[str], None] | None = None,
         data_callback: Callable[[dict], None] | None = None,
         cancel_callback: Callable[[], bool] | None = None,
+        light_intensity_callback: Callable[[float], None] | None = None,
     ) -> None:
         self.smu = smu
         self.lamp = lamp
@@ -91,6 +92,7 @@ class MeasurementProtocol(ABC):
         self._warning_callback = warning_callback
         self._data_callback = data_callback
         self._cancel_callback = cancel_callback
+        self._light_intensity_callback = light_intensity_callback
         self._confirm_callback: Callable[[str, float], bool] | None = None
 
         #: Legacy ``system.measure_light_intensity`` measured for 5 s.
@@ -111,6 +113,7 @@ class MeasurementProtocol(ABC):
         data: Callable[[dict], None] | None = None,
         cancel: Callable[[], bool] | None = None,
         confirm: Callable[[str, float], bool] | None = None,
+        light_intensity: Callable[[float], None] | None = None,
     ) -> None:
         """Attach or replace the interaction callbacks.
 
@@ -128,6 +131,8 @@ class MeasurementProtocol(ABC):
             self._cancel_callback = cancel
         if confirm is not None:
             self._confirm_callback = confirm
+        if light_intensity is not None:
+            self._light_intensity_callback = light_intensity
 
     def status(self, message: str) -> None:
         """Report a status message (legacy ``show_status``)."""
@@ -157,6 +162,16 @@ class MeasurementProtocol(ABC):
         """Report live data for plotting (legacy ``updatePlot*``)."""
         if self._data_callback is not None:
             self._data_callback(data)
+
+    def report_light_intensity(self, light_level: float) -> None:
+        """Report the measured light intensity in % sun.
+
+        Lets the GUI show the measured value as soon as the reference
+        diode reading is done, before the electrical measurement begins
+        (the final result still carries ``light_int_meas``).
+        """
+        if self._light_intensity_callback is not None:
+            self._light_intensity_callback(light_level)
 
     def cancelled(self) -> bool:
         """Whether cancellation was requested (legacy ``abortRunFlag``)."""
@@ -231,6 +246,8 @@ class MeasurementProtocol(ABC):
         light_level = self.measure_light_intensity()
         if self.cancelled():
             return light_level
+        # surface the measured value immediately, before the electrical scan
+        self.report_light_intensity(light_level)
         if light_int > 1.0 and abs((light_level - light_int) / light_int) > 0.1:
             self.warn(
                 "WARNING: Light level measured by reference diode is more "

--- a/src/iv_lab/measurements/workers/base_worker.py
+++ b/src/iv_lab/measurements/workers/base_worker.py
@@ -42,6 +42,9 @@ class MeasurementWorker(QObject):
     #: Emitted when the protocol needs user confirmation; (message, adjusted_dv_V).
     warning_confirmation_needed = Signal(str, float)
     data_ready = Signal(dict)
+    #: Measured light intensity in % sun, emitted as soon as the reference
+    #: diode reading is done (before the electrical measurement begins).
+    light_intensity_ready = Signal(float)
     progress_update = Signal(int)
     finished = Signal(object)
     error = Signal(str)
@@ -71,6 +74,7 @@ class MeasurementWorker(QObject):
             status=self.status_update.emit,
             warning=self.warning_update.emit,
             data=self._on_data,
+            light_intensity=self.light_intensity_ready.emit,
             cancel=self.is_stop_requested,
             # confirm is wired separately via enable_blocking_confirmations()
             # so that non-threaded (test) use auto-proceeds without blocking

--- a/tests/test_measurement_workers.py
+++ b/tests/test_measurement_workers.py
@@ -49,6 +49,7 @@ class SignalRecorder:
         self.status: list[str] = []
         self.warnings: list[str] = []
         self.data: list[dict] = []
+        self.light_intensity: list[float] = []
         self.progress: list[int] = []
         self.results: list[object] = []
         self.errors: list[str] = []
@@ -56,6 +57,7 @@ class SignalRecorder:
         worker.status_update.connect(self.status.append)
         worker.warning_update.connect(self.warnings.append)
         worker.data_ready.connect(self.data.append)
+        worker.light_intensity_ready.connect(self.light_intensity.append)
         worker.progress_update.connect(self.progress.append)
         worker.finished.connect(self.results.append)
         worker.error.connect(self.errors.append)
@@ -191,6 +193,41 @@ def test_worker_runs_and_emits_signals(
     assert recorder.status  # status messages flowed
     assert recorder.data  # live data flowed
     assert "Turning lamp off..." in recorder.status
+
+
+def test_light_intensity_emitted_before_scan_data() -> None:
+    # with a reference diode the measured light level is reported as soon as
+    # the reading is done, before any electrical (data_ready) sample flows
+    smu = make_smu(useReferenceDiode=True)
+    protocol = make_protocol(IVCurveProtocol, smu)
+
+    worker = IVCurveWorker(protocol, iv_params())
+
+    order: list[str] = []
+    worker.light_intensity_ready.connect(lambda _v: order.append("light"))
+    worker.data_ready.connect(lambda _d: order.append("data"))
+    recorder = SignalRecorder(worker)
+
+    worker.run()
+
+    assert recorder.errors == []
+    assert len(recorder.light_intensity) == 1
+    assert recorder.light_intensity[0] >= 0.0
+    # emitted once, ahead of the first scan sample
+    assert order[0] == "light"
+    assert "data" in order
+
+
+def test_no_light_intensity_signal_without_reference_diode() -> None:
+    # default SMU has no reference diode: nothing to report before the scan
+    protocol = make_protocol(IVCurveProtocol)
+    worker = IVCurveWorker(protocol, iv_params())
+    recorder = SignalRecorder(worker)
+
+    worker.run()
+
+    assert recorder.errors == []
+    assert recorder.light_intensity == []
 
 
 def test_progress_is_derived_and_bounded() -> None:


### PR DESCRIPTION
## Summary

The "Measured Light Intensity" label (top-left "Light Level" box) only updated **after** a full measurement run finished. This shows the value as soon as the reference-diode reading completes — before the Voc check and electrical scan begin.

## How it works

The measured value now flows through the same signal layers as the existing status/data signals:

- **`protocols/base.py`** — new `light_intensity_callback` (+ `report_light_intensity()` helper), invoked from `check_light_level()` right after the reading (skipped on cancel). All four protocols (J-V, constant-V, constant-I, MPP) go through `check_light_level`, so all benefit.
- **`workers/base_worker.py`** — new `light_intensity_ready = Signal(float)`, wired as the protocol callback.
- **`core/system.py`** — new GUI-facing `light_intensity_measured = Signal(float)`, re-emitting each worker's signal.
- **`gui/main_window.py`** — connects it to `light_panel.update_measured_intensity`.

The end-of-run update is preserved, so for parallel-reference systems the scan-averaged value still refines the display at the end. On systems without a reference diode, nothing fires (no measured intensity to show) — same as before.

## Tests

`python -m pytest` → 425 passed. Added two tests in `tests/test_measurement_workers.py`:

- `test_light_intensity_emitted_before_scan_data` — with a reference diode, the light signal fires once and **before** the first `data_ready` sample.
- `test_no_light_intensity_signal_without_reference_diode` — no diode means no premature signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
